### PR TITLE
Extract resolveNode for testable network resolution

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,14 +43,19 @@ func Parse() *Config {
 	flag.Parse()
 
 	if cfg.Node == "" {
-		node, ok := networkNodes[cfg.Network]
-		if !ok {
-			node = networkNodes["mainnet"]
-		}
-		cfg.Node = node
+		cfg.Node = resolveNode(cfg.Network)
 	}
 
 	return cfg
+}
+
+// resolveNode returns the gRPC endpoint for the given network name,
+// falling back to mainnet if the network is unknown.
+func resolveNode(network string) string {
+	if node, ok := networkNodes[network]; ok {
+		return node
+	}
+	return networkNodes["mainnet"]
 }
 
 // IsHostedMode returns true when running in HTTP (hosted) mode.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,14 +76,24 @@ func TestNetworkNodes(t *testing.T) {
 	}
 }
 
-func TestNetworkNodes_UnknownFallsToMainnet(t *testing.T) {
-	_, ok := networkNodes["unknown"]
-	if ok {
-		t.Error("unknown network should not be in networkNodes")
+func TestResolveNode(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+		want    string
+	}{
+		{"mainnet", "mainnet", "grpc.trongrid.io:50051"},
+		{"nile", "nile", "grpc.nile.trongrid.io:50051"},
+		{"shasta", "shasta", "grpc.shasta.trongrid.io:50051"},
+		{"unknown falls back to mainnet", "unknown", "grpc.trongrid.io:50051"},
+		{"empty falls back to mainnet", "", "grpc.trongrid.io:50051"},
 	}
-	// Parse logic falls back to mainnet for unknown networks
-	mainnet := networkNodes["mainnet"]
-	if mainnet != "grpc.trongrid.io:50051" {
-		t.Errorf("mainnet fallback = %q, want grpc.trongrid.io:50051", mainnet)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveNode(tt.network)
+			if got != tt.want {
+				t.Errorf("resolveNode(%q) = %q, want %q", tt.network, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Extract `resolveNode(network string) string` from `Parse()` for testable network-to-endpoint resolution
- `Parse()` now delegates to `resolveNode()` internally
- Replace `TestNetworkNodes_UnknownFallsToMainnet` with `TestResolveNode` that exercises the actual fallback logic (mainnet, nile, shasta, unknown, empty)

Closes #7

## Test plan

- [x] `make fmt` — no changes
- [x] `make lint` — 0 issues
- [x] `make test` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal network configuration handling with centralized endpoint resolution, ensuring better fallback behavior for unknown networks.

* **Tests**
  * Enhanced test coverage for network resolution with comprehensive test cases covering mainnet, testnet variants, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->