### PR TITLE
Rename grpc variable to conn across all tool handlers

### DIFF
--- a/internal/tools/account.go
+++ b/internal/tools/account.go
@@ -35,13 +35,13 @@ func RegisterAccountTools(s *server.MCPServer, pool *nodepool.Pool) {
 func handleGetAccount(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		addr := req.GetString("address", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 		if err := validateAddress(addr); err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
 		acc, err := retry.Do(func() (*core.Account, error) {
-			return grpc.GetAccount(addr)
+			return conn.GetAccount(addr)
 		})
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_account: failed to fetch account %s: %v", addr, err)), nil
@@ -79,13 +79,13 @@ func handleGetAccount(pool *nodepool.Pool) server.ToolHandlerFunc {
 func handleGetAccountResources(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		addr := req.GetString("address", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 		if err := validateAddress(addr); err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
 		res, err := retry.Do(func() (*api.AccountResourceMessage, error) {
-			return grpc.GetAccountResource(addr)
+			return conn.GetAccountResource(addr)
 		})
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_account_resources: failed to fetch resources for %s: %v", addr, err)), nil

--- a/internal/tools/contract.go
+++ b/internal/tools/contract.go
@@ -89,12 +89,12 @@ func RegisterContractWriteTools(s *server.MCPServer, pool *nodepool.Pool) {
 func handleListContractMethods(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		contract := req.GetString("contract_address", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 		if err := validateAddress(contract); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid contract address: %v", err)), nil
 		}
 
-		contractABI, err := grpc.GetContractABIResolved(contract)
+		contractABI, err := conn.GetContractABIResolved(contract)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("list_contract_methods: %v", err)), nil
 		}
@@ -169,8 +169,8 @@ func handleDecodeABIOutput(pool *nodepool.Pool) server.ToolHandlerFunc {
 		}
 
 		// Decode output using contract ABI
-		grpc := pool.Client()
-		contractABI, err := grpc.GetContractABIResolved(contract)
+		conn := pool.Client()
+		contractABI, err := conn.GetContractABIResolved(contract)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("decode_abi_output: failed to fetch ABI: %v", err)), nil
 		}
@@ -188,12 +188,12 @@ func handleDecodeABIOutput(pool *nodepool.Pool) server.ToolHandlerFunc {
 func handleGetContractABI(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		contract := req.GetString("contract_address", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 		if err := validateAddress(contract); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid contract address: %v", err)), nil
 		}
 
-		contractABI, err := grpc.GetContractABIResolved(contract)
+		contractABI, err := conn.GetContractABIResolved(contract)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_contract_abi: %v", err)), nil
 		}
@@ -219,7 +219,7 @@ func handleEstimateEnergy(pool *nodepool.Pool) server.ToolHandlerFunc {
 		contract := req.GetString("contract_address", "")
 		method := req.GetString("method", "")
 		params := req.GetString("params", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 
 		if err := validateAddress(from); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
@@ -228,7 +228,7 @@ func handleEstimateEnergy(pool *nodepool.Pool) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid contract address: %v", err)), nil
 		}
 
-		estimate, err := grpc.EstimateEnergy(from, contract, method, params, 0, "", 0)
+		estimate, err := conn.EstimateEnergy(from, contract, method, params, 0, "", 0)
 		if err != nil && isEstimateEnergyUnsupported(err) {
 			// Primary doesn't support EstimateEnergy RPC — try fallback
 			if fallback := pool.FallbackClient(); fallback != nil {
@@ -260,7 +260,7 @@ func handleTriggerConstantContract(pool *nodepool.Pool) server.ToolHandlerFunc {
 		contract := req.GetString("contract_address", "")
 		method := req.GetString("method", "")
 		params := req.GetString("params", "[]")
-		grpc := pool.Client()
+		conn := pool.Client()
 
 		if from != "" {
 			if err := validateAddress(from); err != nil {
@@ -271,7 +271,7 @@ func handleTriggerConstantContract(pool *nodepool.Pool) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid contract address: %v", err)), nil
 		}
 
-		tx, err := grpc.TriggerConstantContract(from, contract, method, params)
+		tx, err := conn.TriggerConstantContract(from, contract, method, params)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("trigger_constant_contract: %v", err)), nil
 		}
@@ -286,7 +286,7 @@ func handleTriggerConstantContract(pool *nodepool.Pool) server.ToolHandlerFunc {
 			result["result_hex"] = hex.EncodeToString(rawResult)
 
 			// Try to decode the result using ABI if available
-			contractABI, abiErr := grpc.GetContractABIResolved(contract)
+			contractABI, abiErr := conn.GetContractABIResolved(contract)
 			if abiErr == nil && contractABI != nil {
 				decoded, decErr := abi.DecodeOutput(contractABI, method, rawResult)
 				if decErr == nil && decoded != nil {
@@ -316,7 +316,7 @@ func handleTriggerContract(pool *nodepool.Pool) server.ToolHandlerFunc {
 		params := req.GetString("params", "")
 		feeLimit := req.GetInt("fee_limit", 100)
 		callValue := req.GetInt("call_value", 0)
-		grpc := pool.Client()
+		conn := pool.Client()
 
 		if err := validateAddress(from); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
@@ -330,7 +330,7 @@ func handleTriggerContract(pool *nodepool.Pool) server.ToolHandlerFunc {
 		}
 		feeLimitSun := int64(feeLimit) * 1_000_000
 
-		tx, err := grpc.TriggerContract(from, contract, method, params, feeLimitSun, int64(callValue), "", 0)
+		tx, err := conn.TriggerContract(from, contract, method, params, feeLimitSun, int64(callValue), "", 0)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("trigger_contract: %v", err)), nil
 		}

--- a/internal/tools/network.go
+++ b/internal/tools/network.go
@@ -106,8 +106,8 @@ func handleGetTransaction(pool *nodepool.Pool) server.ToolHandlerFunc {
 
 func handleGetChainParameters(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		grpc := pool.Client()
-		nodeInfo, err := grpc.GetNodeInfo()
+		conn := pool.Client()
+		nodeInfo, err := conn.GetNodeInfo()
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_chain_parameters: %v", err)), nil
 		}
@@ -120,12 +120,12 @@ func handleGetChainParameters(pool *nodepool.Pool) server.ToolHandlerFunc {
 			},
 		}
 
-		energyPrices, err := grpc.GetEnergyPriceHistory()
+		energyPrices, err := conn.GetEnergyPriceHistory()
 		if err == nil {
 			result["energy_prices"] = energyPrices
 		}
 
-		bwPrices, err := grpc.GetBandwidthPriceHistory()
+		bwPrices, err := conn.GetBandwidthPriceHistory()
 		if err == nil {
 			result["bandwidth_prices"] = bwPrices
 		}
@@ -136,8 +136,8 @@ func handleGetChainParameters(pool *nodepool.Pool) server.ToolHandlerFunc {
 
 func handleGetEnergyPrices(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		grpc := pool.Client()
-		prices, err := grpc.GetEnergyPriceHistory()
+		conn := pool.Client()
+		prices, err := conn.GetEnergyPriceHistory()
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_energy_prices: %v", err)), nil
 		}
@@ -170,8 +170,8 @@ func handleGetNetwork(pool *nodepool.Pool, network, _ string) server.ToolHandler
 
 func handleGetBandwidthPrices(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		grpc := pool.Client()
-		prices, err := grpc.GetBandwidthPriceHistory()
+		conn := pool.Client()
+		prices, err := conn.GetBandwidthPriceHistory()
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_bandwidth_prices: %v", err)), nil
 		}

--- a/internal/tools/proposal.go
+++ b/internal/tools/proposal.go
@@ -23,8 +23,8 @@ func RegisterProposalTools(s *server.MCPServer, pool *nodepool.Pool) {
 
 func handleListProposals(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		grpc := pool.Client()
-		proposals, err := grpc.ProposalsList()
+		conn := pool.Client()
+		proposals, err := conn.ProposalsList()
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("list_proposals: %v", err)), nil
 		}

--- a/internal/tools/resource.go
+++ b/internal/tools/resource.go
@@ -52,7 +52,7 @@ func handleFreezeBalance(pool *nodepool.Pool) server.ToolHandlerFunc {
 		from := req.GetString("from", "")
 		amountStr := req.GetString("amount", "")
 		resourceStr := req.GetString("resource", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 
 		if err := validateAddress(from); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
@@ -71,7 +71,7 @@ func handleFreezeBalance(pool *nodepool.Pool) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		tx, err := grpc.FreezeBalanceV2(from, resource, sun)
+		tx, err := conn.FreezeBalanceV2(from, resource, sun)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("freeze_balance: %v", err)), nil
 		}
@@ -100,7 +100,7 @@ func handleUnfreezeBalance(pool *nodepool.Pool) server.ToolHandlerFunc {
 		from := req.GetString("from", "")
 		amountStr := req.GetString("amount", "")
 		resourceStr := req.GetString("resource", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 
 		if err := validateAddress(from); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
@@ -119,7 +119,7 @@ func handleUnfreezeBalance(pool *nodepool.Pool) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		tx, err := grpc.UnfreezeBalanceV2(from, resource, sun)
+		tx, err := conn.UnfreezeBalanceV2(from, resource, sun)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("unfreeze_balance: %v", err)), nil
 		}

--- a/internal/tools/sign.go
+++ b/internal/tools/sign.go
@@ -103,7 +103,7 @@ func handleSignTransaction(keystorePath string) server.ToolHandlerFunc {
 func handleBroadcastTransaction(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		txHex := req.GetString("signed_transaction_hex", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 		if txHex == "" {
 			return mcp.NewToolResultError("signed_transaction_hex is required"), nil
 		}
@@ -121,7 +121,7 @@ func handleBroadcastTransaction(pool *nodepool.Pool) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("failed to parse transaction: %v", err)), nil
 		}
 
-		ret, err := grpc.Broadcast(&tx)
+		ret, err := conn.Broadcast(&tx)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("broadcast_transaction: %v", err)), nil
 		}

--- a/internal/tools/token.go
+++ b/internal/tools/token.go
@@ -36,7 +36,7 @@ func handleGetTRC20Balance(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		addr := req.GetString("address", "")
 		contract := req.GetString("contract_address", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 
 		if err := validateAddress(addr); err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
@@ -46,27 +46,27 @@ func handleGetTRC20Balance(pool *nodepool.Pool) server.ToolHandlerFunc {
 		}
 
 		balance, err := retry.Do(func() (*big.Int, error) {
-			return grpc.TRC20ContractBalance(addr, contract)
+			return conn.TRC20ContractBalance(addr, contract)
 		})
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_trc20_balance: %v", err)), nil
 		}
 
 		decimals, err := retry.Do(func() (*big.Int, error) {
-			return grpc.TRC20GetDecimals(contract)
+			return conn.TRC20GetDecimals(contract)
 		})
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_trc20_balance: failed to get decimals: %v", err)), nil
 		}
 
 		name, err := retry.Do(func() (string, error) {
-			return grpc.TRC20GetName(contract)
+			return conn.TRC20GetName(contract)
 		})
 		if err != nil {
 			name = ""
 		}
 		symbol, err := retry.Do(func() (string, error) {
-			return grpc.TRC20GetSymbol(contract)
+			return conn.TRC20GetSymbol(contract)
 		})
 		if err != nil {
 			symbol = ""
@@ -94,22 +94,22 @@ func handleGetTRC20Balance(pool *nodepool.Pool) server.ToolHandlerFunc {
 func handleGetTRC20TokenInfo(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		contract := req.GetString("contract_address", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 		if err := validateAddress(contract); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid contract address: %v", err)), nil
 		}
 
-		name, err := grpc.TRC20GetName(contract)
+		name, err := conn.TRC20GetName(contract)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_trc20_token_info: failed to get name: %v", err)), nil
 		}
 
-		symbol, err := grpc.TRC20GetSymbol(contract)
+		symbol, err := conn.TRC20GetSymbol(contract)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_trc20_token_info: failed to get symbol: %v", err)), nil
 		}
 
-		decimals, err := grpc.TRC20GetDecimals(contract)
+		decimals, err := conn.TRC20GetDecimals(contract)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("get_trc20_token_info: failed to get decimals: %v", err)), nil
 		}

--- a/internal/tools/transfer.go
+++ b/internal/tools/transfer.go
@@ -43,7 +43,7 @@ func handleTransferTRX(pool *nodepool.Pool) server.ToolHandlerFunc {
 		from := req.GetString("from", "")
 		to := req.GetString("to", "")
 		amountStr := req.GetString("amount", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 
 		if err := validateAddress(from); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
@@ -60,7 +60,7 @@ func handleTransferTRX(pool *nodepool.Pool) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("amount must be greater than zero"), nil
 		}
 
-		tx, err := grpc.Transfer(from, to, sun)
+		tx, err := conn.Transfer(from, to, sun)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("transfer_trx: %v", err)), nil
 		}
@@ -91,7 +91,7 @@ func handleTransferTRC20(pool *nodepool.Pool) server.ToolHandlerFunc {
 		contract := req.GetString("contract_address", "")
 		amountStr := req.GetString("amount", "")
 		feeLimit := req.GetInt("fee_limit", 100)
-		grpc := pool.Client()
+		conn := pool.Client()
 
 		if err := validateAddress(from); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
@@ -103,7 +103,7 @@ func handleTransferTRC20(pool *nodepool.Pool) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid contract address: %v", err)), nil
 		}
 
-		decimals, err := grpc.TRC20GetDecimals(contract)
+		decimals, err := conn.TRC20GetDecimals(contract)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("transfer_trc20: failed to get decimals: %v", err)), nil
 		}
@@ -125,7 +125,7 @@ func handleTransferTRC20(pool *nodepool.Pool) server.ToolHandlerFunc {
 		}
 		feeLimitSun := int64(feeLimit) * 1_000_000
 
-		tx, err := grpc.TRC20Send(from, to, contract, amount, feeLimitSun)
+		tx, err := conn.TRC20Send(from, to, contract, amount, feeLimitSun)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("transfer_trc20: %v", err)), nil
 		}

--- a/internal/tools/witness.go
+++ b/internal/tools/witness.go
@@ -36,8 +36,8 @@ func RegisterWitnessWriteTools(s *server.MCPServer, pool *nodepool.Pool) {
 
 func handleListWitnesses(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		grpc := pool.Client()
-		witnesses, err := grpc.ListWitnesses()
+		conn := pool.Client()
+		witnesses, err := conn.ListWitnesses()
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("list_witnesses: %v", err)), nil
 		}
@@ -68,7 +68,7 @@ func handleListWitnesses(pool *nodepool.Pool) server.ToolHandlerFunc {
 func handleVoteWitness(pool *nodepool.Pool) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		from := req.GetString("from", "")
-		grpc := pool.Client()
+		conn := pool.Client()
 		if err := validateAddress(from); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
 		}
@@ -105,7 +105,7 @@ func handleVoteWitness(pool *nodepool.Pool) server.ToolHandlerFunc {
 			}
 		}
 
-		tx, err := grpc.VoteWitnessAccount(from, witnessVotes)
+		tx, err := conn.VoteWitnessAccount(from, witnessVotes)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("vote_witness: %v", err)), nil
 		}


### PR DESCRIPTION
## Summary

Renames the `grpc` local variable to `conn` in all 9 tool handler files to eliminate shadowing of the `google.golang.org/grpc` package name. Pure rename — no logic changes.

21 occurrences across: account.go, block.go (already done in PR #5), contract.go, network.go, proposal.go, resource.go, sign.go, token.go, transfer.go, witness.go

Closes #3

## Test plan

- [x] `make fmt` — no changes
- [x] `make lint` — 0 issues
- [x] `make test` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code maintainability through standardized naming conventions across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->