### PR TITLE
Accept plain params with type inference from method signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fbsobreira/gotron-mcp
 go 1.25.1
 
 require (
-	github.com/fbsobreira/gotron-sdk v0.25.0
+	github.com/fbsobreira/gotron-sdk v0.25.2-0.20260319012410-79c585fec786
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/mark3labs/mcp-go v0.45.0
 	golang.org/x/time v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/ethereum/go-ethereum v1.17.0 h1:2D+1Fe23CwZ5tQoAS5DfwKFNI1HGcTwi65/kR
 github.com/ethereum/go-ethereum v1.17.0/go.mod h1:2W3msvdosS/MCWytpqTcqgFiRYbTH59FxDJzqah120o=
 github.com/fbsobreira/go-bip39 v1.2.0 h1:zp3VDGrQeGu8/iPB5wsHVSaOwQhBSLR71CE3nJVz4mY=
 github.com/fbsobreira/go-bip39 v1.2.0/go.mod h1:PRuO9kYh4Kn+tRALmXYtbizPeD8G2qm8FTVgxDaiXTM=
-github.com/fbsobreira/gotron-sdk v0.25.0 h1:6qa4DJAI8MINlGGUXPWOOrxWmg3HxJxURi0Nb2rVeKI=
-github.com/fbsobreira/gotron-sdk v0.25.0/go.mod h1:3YuSi4qc3lJ48uooeTaEawXJvuZQ/wZ/rQQo+X/PPxA=
+github.com/fbsobreira/gotron-sdk v0.25.2-0.20260319012410-79c585fec786 h1:68ZsItVAscuad06nSuhr+/BEtpD9esCeQAT49og1VfM=
+github.com/fbsobreira/gotron-sdk v0.25.2-0.20260319012410-79c585fec786/go.mod h1:3YuSi4qc3lJ48uooeTaEawXJvuZQ/wZ/rQQo+X/PPxA=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/resources/knowledge/topics/contracts.md
+++ b/internal/resources/knowledge/topics/contracts.md
@@ -10,30 +10,64 @@
 ## SDK: Read-Only Calls
 
 ```go
-// No transaction created, no fees
-result, err := conn.TriggerConstantContract(
+// No transaction created, no fees — plain-value params (types inferred from signature)
+result, err := conn.TriggerConstantContractCtx(ctx,
     "TCallerAddr...",
     "TContractAddr...",
     "balanceOf(address)",
-    `[{"address": "TOwnerAddr..."}]`,
+    `["TOwnerAddr..."]`,
 )
 // result.ConstantResult contains the return data
+
+// Simulate payable functions with WithCallValue (msg.value in SUN)
+result, err := conn.TriggerConstantContractCtx(ctx,
+    "TCallerAddr...", "TContractAddr...",
+    "deposit()", `[]`,
+    client.WithCallValue(1_000_000), // 1 TRX
+)
+
+// With TRC10 token value
+opt, err := client.WithTokenValue("1000001", 500)
+result, err := conn.TriggerConstantContractCtx(ctx,
+    "TCallerAddr...", "TContractAddr...",
+    "onTokenReceived()", `[]`,
+    opt,
+)
 ```
 
 ## SDK: Write Calls
 
 ```go
-tx, err := conn.TriggerContract(
+// Plain-value params (types inferred from method signature)
+tx, err := conn.TriggerContractCtx(ctx,
     "TCallerAddr...",                         // from
     "TContractAddr...",                       // contract
     "transfer(address,uint256)",              // method signature
-    `[{"address":"TToAddr..."},{"uint256":"1000000"}]`,  // params as JSON
+    `["TToAddr...", "1000000"]`,              // params (plain-value format)
     100_000_000,                              // fee limit (100 TRX in SUN)
     0,                                        // call value (TRX to send, in SUN)
     "",                                       // token ID (empty for TRX)
     0,                                        // token amount
 )
 // Returns unsigned transaction
+```
+
+## SDK: Pre-Packed ABI Data Calls
+
+For callers that already have ABI-packed data (e.g., from go-ethereum's `abi.Pack()`):
+
+```go
+// Read-only call with pre-packed data
+result, err := conn.TriggerConstantContractWithDataCtx(ctx,
+    "TCallerAddr...", "TContractAddr...", packedData,
+)
+
+// Write call with pre-packed data
+tx, err := conn.TriggerContractWithDataCtx(ctx,
+    "TCallerAddr...", "TContractAddr...", packedData,
+    100_000_000, // fee limit
+    0, "", 0,    // callValue, tokenID, tokenAmount
+)
 ```
 
 ## SDK: Get Contract ABI
@@ -71,7 +105,24 @@ The SDK supports overloaded contract methods (same name, different parameters):
 
 ## Parameter Encoding
 
-Parameters are passed as a JSON array of typed values:
+Two parameter formats are supported. The SDK auto-detects which format is used.
+
+### Plain-Value Format (recommended)
+
+Pass values directly — types are inferred from the method signature:
+
+```json
+["TXyz...", "1000000"]
+```
+
+Examples:
+- `balanceOf(address)` → `["TJDENsfBJs4RFETt1X1W8wMDc8M5XnS5f4"]`
+- `transfer(address,uint256)` → `["TJDENsfBJs4RFETt1X1W8wMDc8M5XnS5f4", "1000000"]`
+- `approve(address,uint256)` → `["TJDENsfBJs4RFETt1X1W8wMDc8M5XnS5f4", "100"]`
+
+### Typed-Object Format (also supported)
+
+Explicitly specify the type for each parameter:
 
 ```json
 [
@@ -90,6 +141,18 @@ Supported array types:
     {"address[]": ["TAddr1...", "TAddr2..."]},
     {"bytes[]": ["0xab", "0xcd"]}
 ]
+```
+
+### SDK: Parameter Parsing
+
+```go
+import "github.com/fbsobreira/gotron-sdk/pkg/abi"
+
+// Auto-detect format and infer types from method signature
+params, err := abi.LoadFromJSONWithMethod("transfer(address,uint256)", `["TJD...", "1000"]`)
+
+// Or use typed-object format directly
+params, err := abi.LoadFromJSON(`[{"address": "TJD..."}, {"uint256": "1000"}]`)
 ```
 
 ## Fee Limits

--- a/internal/tools/contract.go
+++ b/internal/tools/contract.go
@@ -29,7 +29,7 @@ func RegisterContractReadTools(s *server.MCPServer, pool *nodepool.Pool) {
 			mcp.WithString("from", mcp.Description("Caller address (base58, starts with T; optional — defaults to zero address)")),
 			mcp.WithString("contract_address", mcp.Required(), mcp.Description("Smart contract address (base58, starts with T)")),
 			mcp.WithString("method", mcp.Required(), mcp.Description("Method signature (e.g., 'totalSupply()', 'balanceOf(address)')")),
-			mcp.WithString("params", mcp.Description("Method parameters as JSON array of {type: value} objects, e.g., [{\"address\": \"TJD...\"}, {\"uint256\": \"1000\"}]")),
+			mcp.WithString("params", mcp.Description("Method parameters as JSON array. Plain values: [\"TJD...\", \"1000\"] (types inferred from method signature). Typed objects also accepted: [{\"address\": \"TJD...\"}, {\"uint256\": \"1000\"}]")),
 		),
 		handleTriggerConstantContract(pool),
 	)
@@ -66,7 +66,7 @@ func RegisterContractReadTools(s *server.MCPServer, pool *nodepool.Pool) {
 			mcp.WithString("from", mcp.Required(), mcp.Description("Caller address (base58, starts with T)")),
 			mcp.WithString("contract_address", mcp.Required(), mcp.Description("Smart contract address (base58, starts with T)")),
 			mcp.WithString("method", mcp.Required(), mcp.Description("Contract method signature (e.g., 'transfer(address,uint256)')")),
-			mcp.WithString("params", mcp.Required(), mcp.Description("Method parameters as JSON array of {type: value} objects, e.g., [{\"address\": \"TJD...\"}, {\"uint256\": \"1000\"}]")),
+			mcp.WithString("params", mcp.Required(), mcp.Description("Method parameters as JSON array. Plain values: [\"TJD...\", \"1000\"] (types inferred from method signature). Typed objects also accepted: [{\"address\": \"TJD...\"}, {\"uint256\": \"1000\"}]")),
 		),
 		handleEstimateEnergy(pool),
 	)
@@ -80,7 +80,7 @@ func RegisterContractWriteTools(s *server.MCPServer, pool *nodepool.Pool) {
 			mcp.WithString("from", mcp.Required(), mcp.Description("Caller address (base58, starts with T)")),
 			mcp.WithString("contract_address", mcp.Required(), mcp.Description("Smart contract address (base58, starts with T)")),
 			mcp.WithString("method", mcp.Required(), mcp.Description("Method signature (e.g., 'transfer(address,uint256)')")),
-			mcp.WithString("params", mcp.Required(), mcp.Description("Method parameters as JSON array of {type: value} objects, e.g., [{\"address\": \"TJD...\"}, {\"uint256\": \"1000\"}]")),
+			mcp.WithString("params", mcp.Required(), mcp.Description("Method parameters as JSON array. Plain values: [\"TJD...\", \"1000\"] (types inferred from method signature). Typed objects also accepted: [{\"address\": \"TJD...\"}, {\"uint256\": \"1000\"}]")),
 			mcp.WithNumber("fee_limit", mcp.Description("Fee limit in whole TRX (integer), range 0-15000 (default: 100)")),
 			mcp.WithNumber("call_value", mcp.Description("Amount to send with call in SUN (default: 0)")),
 		),

--- a/internal/tools/contract_test.go
+++ b/internal/tools/contract_test.go
@@ -577,3 +577,106 @@ func TestTriggerContract_Error(t *testing.T) {
 		t.Error("expected error when TriggerContract fails")
 	}
 }
+
+// Plain-value parameter format tests — types inferred from method signature.
+// These verify that the SDK's abi.LoadFromJSONWithMethod() works end-to-end
+// through the MCP tool handlers after the gotron-sdk upgrade.
+
+func TestTriggerConstantContract_PlainParams(t *testing.T) {
+	mock := mockContractServer()
+	mock.TriggerConstantContractFunc = func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+		return &api.TransactionExtention{
+			ConstantResult: [][]byte{abiEncodeUint256(big.NewInt(1000000))},
+			Result:         &api.Return{Result: true},
+		}, nil
+	}
+	pool := newMockPool(t, mock)
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"plain-value format", `["TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF"]`},
+		{"typed-object format", `[{"address": "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF"}]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callTool(t, handleTriggerConstantContract(pool), map[string]any{
+				"contract_address": "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+				"method":           "balanceOf(address)",
+				"params":           tt.params,
+			})
+			if result.IsError {
+				t.Fatalf("expected success, got error: %v", result.Content)
+			}
+		})
+	}
+}
+
+func TestEstimateEnergy_PlainParams(t *testing.T) {
+	mock := &mockWalletServer{
+		EstimateEnergyFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.EstimateEnergyMessage, error) {
+			return &api.EstimateEnergyMessage{
+				Result:         &api.Return{Result: true},
+				EnergyRequired: 31895,
+			}, nil
+		},
+	}
+	pool := newMockPool(t, mock)
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"plain-value format", `["TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF", "1000000"]`},
+		{"typed-object format", `[{"address": "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF"}, {"uint256": "1000000"}]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callTool(t, handleEstimateEnergy(pool), map[string]any{
+				"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+				"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+				"method":           "transfer(address,uint256)",
+				"params":           tt.params,
+			})
+			if result.IsError {
+				t.Fatalf("expected success, got error: %v", result.Content)
+			}
+		})
+	}
+}
+
+func TestTriggerContract_PlainParams(t *testing.T) {
+	mock := &mockWalletServer{
+		TriggerContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			return &api.TransactionExtention{
+				Result:      &api.Return{Result: true},
+				Txid:        make([]byte, 32),
+				Transaction: &core.Transaction{RawData: &core.TransactionRaw{}},
+			}, nil
+		},
+	}
+	pool := newMockPool(t, mock)
+
+	tests := []struct {
+		name   string
+		params string
+	}{
+		{"plain-value format", `["TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF", "1000000"]`},
+		{"typed-object format", `[{"address": "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF"}, {"uint256": "1000000"}]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := callTool(t, handleTriggerContract(pool), map[string]any{
+				"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+				"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+				"method":           "transfer(address,uint256)",
+				"params":           tt.params,
+				"fee_limit":        float64(100),
+			})
+			if result.IsError {
+				t.Fatalf("expected success, got error: %v", result.Content)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Upgrade gotron-sdk to latest master (`v0.25.2-0.20260319012410`) which adds `abi.LoadFromJSONWithMethod()` for automatic parameter type inference
- Contract tools now accept plain-value JSON params `["TJD...", "1000"]` in addition to typed-object format `[{"address": "TJD..."}, {"uint256": "1000"}]`
- Update knowledge base with new SDK methods: `WithCallValue()`, `WithTokenValue()`, `TriggerContractWithData`, `TriggerConstantContractWithData`

## Affected Tools

- `trigger_constant_contract`
- `trigger_contract`
- `estimate_energy`

## Test plan

- [x] Plain-value format works for all 3 contract tools
- [x] Typed-object format still works (backward compatible)
- [x] Full test suite passes (`make test`)
- [x] Lint clean (`make lint` — 0 issues)
- [x] Build succeeds (`make build`)

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contract calls now support plain-value parameter format alongside typed-object format with automatic type inference from method signatures.
  * Added support for pre-packed ABI data calls for both read-only and write operations.
  * Enhanced constant call options including support for payable/simulated value and token-value scenarios.

* **Documentation**
  * Updated contract call examples and expanded parameter encoding documentation with additional usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->