### PR TITLE
Add TRC20 energy estimation tool via WithEstimate()

### DIFF
--- a/internal/resources/knowledge/topics/tokens.md
+++ b/internal/resources/knowledge/topics/tokens.md
@@ -103,3 +103,4 @@ energy, err := token.Transfer(from, to, amount).EstimateEnergy(ctx)
 - `get_trc20_balance` — Get TRC20 token balance for an account
 - `get_trc20_token_info` — Get token name, symbol, and decimals
 - `transfer_trc20` — Create unsigned TRC20 transfer transaction
+- `estimate_trc20_energy` — Estimate energy cost for a TRC20 transfer (dry-run)

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -27,9 +27,9 @@ func TestRegisterAllTools(t *testing.T) {
 	tools := s.ListTools()
 
 	// Expected: 2 account + 1 address + 1 block + 5 contract read + 1 contract write +
-	// 8 network (5 existing + 3 pending pool) + 1 proposal + 2 resource + 2 sign + 2 token + 2 transfer +
-	// 1 witness read + 1 witness write = 29
-	const expectedToolCount = 29
+	// 8 network (5 existing + 3 pending pool) + 1 proposal + 2 resource + 2 sign + 3 token + 2 transfer +
+	// 1 witness read + 1 witness write = 30
+	const expectedToolCount = 30
 	if len(tools) != expectedToolCount {
 		t.Errorf("registered tool count = %d, want %d", len(tools), expectedToolCount)
 	}
@@ -54,6 +54,7 @@ func TestRegisterAllTools(t *testing.T) {
 		"get_pending_transactions",
 		"is_transaction_pending",
 		"get_pending_by_address",
+		"estimate_trc20_energy",
 	}
 	for _, name := range representative {
 		if tools[name] == nil {

--- a/internal/tools/token.go
+++ b/internal/tools/token.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fbsobreira/gotron-mcp/internal/nodepool"
 	"github.com/fbsobreira/gotron-mcp/internal/retry"
 	"github.com/fbsobreira/gotron-mcp/internal/util"
+	"github.com/fbsobreira/gotron-sdk/pkg/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -29,6 +30,17 @@ func RegisterTokenTools(s *server.MCPServer, pool *nodepool.Pool) {
 			mcp.WithString("contract_address", mcp.Required(), mcp.Description("TRC20 contract address")),
 		),
 		handleGetTRC20TokenInfo(pool),
+	)
+
+	s.AddTool(
+		mcp.NewTool("estimate_trc20_energy",
+			mcp.WithDescription("Estimate energy cost for a TRC20 transfer without creating a transaction. Dry-runs the transfer to check energy requirements."),
+			mcp.WithString("from", mcp.Required(), mcp.Description("Sender address (base58, starts with T)")),
+			mcp.WithString("to", mcp.Required(), mcp.Description("Recipient address (base58, starts with T)")),
+			mcp.WithString("contract_address", mcp.Required(), mcp.Description("TRC20 contract address (base58, starts with T)")),
+			mcp.WithString("amount", mcp.Required(), mcp.Description("Amount in human-readable units (e.g., '100.5' for 100.5 USDT)")),
+		),
+		handleEstimateTRC20Energy(pool),
 	)
 }
 
@@ -121,6 +133,58 @@ func handleGetTRC20TokenInfo(pool *nodepool.Pool) server.ToolHandlerFunc {
 			"name":             name,
 			"symbol":           symbol,
 			"decimals":         decimals.Int64(),
+		}
+
+		return mcp.NewToolResultJSON(result)
+	}
+}
+
+func handleEstimateTRC20Energy(pool *nodepool.Pool) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		from := req.GetString("from", "")
+		to := req.GetString("to", "")
+		contract := req.GetString("contract_address", "")
+		amountStr := req.GetString("amount", "")
+		conn := pool.Client()
+
+		if err := validateAddress(from); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
+		}
+		if err := validateAddress(to); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid to address: %v", err)), nil
+		}
+		if err := validateAddress(contract); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid contract address: %v", err)), nil
+		}
+
+		decimals, err := conn.TRC20GetDecimalsCtx(ctx, contract)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("estimate_trc20_energy: failed to get decimals: %v", err)), nil
+		}
+		if decimals == nil || decimals.Sign() < 0 || decimals.Cmp(big.NewInt(77)) > 0 {
+			return mcp.NewToolResultError(fmt.Sprintf("estimate_trc20_energy: invalid decimals value: %s", decimals)), nil
+		}
+		dec := int(decimals.Int64())
+
+		amount, err := util.ParseTRC20Amount(amountStr, dec)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid amount: %v", err)), nil
+		}
+		if amount.Sign() <= 0 {
+			return mcp.NewToolResultError("amount must be greater than zero"), nil
+		}
+
+		tx, err := conn.TRC20SendCtx(ctx, from, to, contract, amount, 0, client.WithEstimate())
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("estimate_trc20_energy: %v", err)), nil
+		}
+
+		result := map[string]any{
+			"from":             from,
+			"to":               to,
+			"contract_address": contract,
+			"amount":           amountStr,
+			"estimated_energy": tx.EnergyUsed,
 		}
 
 		return mcp.NewToolResultJSON(result)

--- a/internal/tools/token_test.go
+++ b/internal/tools/token_test.go
@@ -70,6 +70,124 @@ func mockTRC20Server(balance *big.Int, decimals int64, name, symbol string) *moc
 	}
 }
 
+// mockTRC20EstimateServer extends mockTRC20Server to also handle
+// transfer(address,uint256) selector for WithEstimate() dry-runs.
+func mockTRC20EstimateServer(decimals int64, energyUsed int64) *mockWalletServer {
+	return &mockWalletServer{
+		TriggerConstantContractFunc: func(_ context.Context, in *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			data := in.Data
+			if len(data) < 4 {
+				return nil, fmt.Errorf("unexpected short calldata: %x", data)
+			}
+
+			selector := data[:4]
+			var result []byte
+			switch {
+			case bytes.Equal(selector, []byte{0x31, 0x3c, 0xe5, 0x67}): // decimals()
+				result = abiEncodeUint256(big.NewInt(decimals))
+			case bytes.Equal(selector, []byte{0xa9, 0x05, 0x9c, 0xbb}): // transfer(address,uint256)
+				result = abiEncodeUint256(big.NewInt(1)) // success = true
+			default:
+				return nil, fmt.Errorf("unexpected selector: %x", selector)
+			}
+
+			return &api.TransactionExtention{
+				ConstantResult: [][]byte{result},
+				Result:         &api.Return{Result: true},
+				EnergyUsed:     energyUsed,
+			}, nil
+		},
+	}
+}
+
+func TestEstimateTRC20Energy_Success(t *testing.T) {
+	mock := mockTRC20EstimateServer(6, 29000)
+	pool := newMockPool(t, mock)
+	result := callTool(t, handleEstimateTRC20Energy(pool), map[string]any{
+		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"to":               "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"amount":           "100",
+	})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %v", result.Content)
+	}
+	data := parseJSONResult(t, result)
+	if data["estimated_energy"] != float64(29000) {
+		t.Errorf("estimated_energy = %v, want 29000", data["estimated_energy"])
+	}
+	if data["from"] != "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF" {
+		t.Errorf("from = %v, want TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF", data["from"])
+	}
+}
+
+func TestEstimateTRC20Energy_InvalidTo(t *testing.T) {
+	pool := newMockPool(t, &mockWalletServer{})
+	result := callTool(t, handleEstimateTRC20Energy(pool), map[string]any{
+		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"to":               "bad",
+		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"amount":           "100",
+	})
+	if !result.IsError {
+		t.Error("expected error for invalid to address")
+	}
+}
+
+func TestEstimateTRC20Energy_InvalidContract(t *testing.T) {
+	pool := newMockPool(t, &mockWalletServer{})
+	result := callTool(t, handleEstimateTRC20Energy(pool), map[string]any{
+		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"to":               "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"contract_address": "bad",
+		"amount":           "100",
+	})
+	if !result.IsError {
+		t.Error("expected error for invalid contract address")
+	}
+}
+
+func TestEstimateTRC20Energy_InvalidFrom(t *testing.T) {
+	pool := newMockPool(t, &mockWalletServer{})
+	result := callTool(t, handleEstimateTRC20Energy(pool), map[string]any{
+		"from":             "bad",
+		"to":               "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"amount":           "100",
+	})
+	if !result.IsError {
+		t.Error("expected error for invalid from address")
+	}
+}
+
+func TestEstimateTRC20Energy_InvalidAmount(t *testing.T) {
+	mock := mockTRC20EstimateServer(6, 29000)
+	pool := newMockPool(t, mock)
+	result := callTool(t, handleEstimateTRC20Energy(pool), map[string]any{
+		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"to":               "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"amount":           "not-a-number",
+	})
+	if !result.IsError {
+		t.Error("expected error for invalid amount")
+	}
+}
+
+func TestEstimateTRC20Energy_ZeroAmount(t *testing.T) {
+	mock := mockTRC20EstimateServer(6, 29000)
+	pool := newMockPool(t, mock)
+	result := callTool(t, handleEstimateTRC20Energy(pool), map[string]any{
+		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"to":               "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		"amount":           "0",
+	})
+	if !result.IsError {
+		t.Error("expected error for zero amount")
+	}
+}
+
 func TestGetTRC20Balance_InvalidAddress(t *testing.T) {
 	pool := newMockPool(t, &mockWalletServer{})
 	result := callTool(t, handleGetTRC20Balance(pool), map[string]any{


### PR DESCRIPTION
## Summary

Add `estimate_trc20_energy` tool that dry-runs TRC20 transfers to estimate energy cost without creating a transaction. Uses `client.WithEstimate()` from gotron-sdk v0.25.2.

**No `fee_limit` parameter** — the SDK ignores it in constant/estimate mode, so exposing it would be misleading. Passes 0 internally.

## Example

```json
{
  "from": "TSender...",
  "to": "TReceiver...",
  "contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
  "amount": "100.5",
  "estimated_energy": 29000
}
```

## Use Cases

- Agent checks energy cost before executing a USDT transfer
- Agent compares energy costs across different TRC20 tokens
- Agent advises user on whether they have enough staked energy

## Test plan

- [x] Success test with mock TRC20 estimate server
- [x] Invalid from/to/contract address validation
- [x] Invalid amount (non-numeric)
- [x] Zero amount rejection
- [x] Tool registration count updated (29→30) with name assertion
- [x] Full test suite passes (`make test`)
- [x] Lint clean (`make lint` — 0 issues)
- [x] Build succeeds (`make build`)
- [x] goimports clean (`make fmt`)

Reviewed by: CodeRabbit CLI, Codex MCP, coderabbit:code-reviewer agent.

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added energy cost estimation tool for TRC20 token transfers via dry-run simulation.
  * Validates TRON addresses and token amounts before processing estimation requests.

* **Tests**
  * Added comprehensive test coverage for the new energy estimation tool, including success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->