### PR TITLE
fix: bump gotron-sdk and adapt to HexToAddress breaking change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,11 @@ defer conn.Stop()
 import "github.com/fbsobreira/gotron-sdk/pkg/address"
 
 addrB58, err := address.Base58ToAddress("TXyz...")  // validates + converts
-addrHex := address.HexToAddress("41...")             // no validation
-addrB58.String()   // base58
-addrHex.Hex()      // hex with 41 prefix
-addrB58.IsValid()  // check validity
+addrHex, err := address.HexToAddress("41...")       // validates + converts
+addr := address.BytesToAddress(rawBytes)            // from raw bytes (no error)
+addr.String()      // base58
+addr.Hex()         // hex with 41 prefix
+addr.IsValid()     // check validity (validates checksum)
 ```
 
 ### Amount Conventions

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fbsobreira/gotron-mcp
 go 1.25.1
 
 require (
-	github.com/fbsobreira/gotron-sdk v0.25.3-0.20260320011456-9df99c2a94f4
+	github.com/fbsobreira/gotron-sdk v0.25.3-0.20260320202924-6eab686352bd
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/mark3labs/mcp-go v0.45.0
 	golang.org/x/time v0.15.0
@@ -26,7 +26,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rjeczalik/notify v0.9.3 // indirect
 	github.com/shengdoushi/base58 v1.0.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/ethereum/go-ethereum v1.17.0 h1:2D+1Fe23CwZ5tQoAS5DfwKFNI1HGcTwi65/kR
 github.com/ethereum/go-ethereum v1.17.0/go.mod h1:2W3msvdosS/MCWytpqTcqgFiRYbTH59FxDJzqah120o=
 github.com/fbsobreira/go-bip39 v1.2.0 h1:zp3VDGrQeGu8/iPB5wsHVSaOwQhBSLR71CE3nJVz4mY=
 github.com/fbsobreira/go-bip39 v1.2.0/go.mod h1:PRuO9kYh4Kn+tRALmXYtbizPeD8G2qm8FTVgxDaiXTM=
-github.com/fbsobreira/gotron-sdk v0.25.3-0.20260320011456-9df99c2a94f4 h1:pCznAKHW6zDDTWcUqHAt/gCQFNNl8OBRjlHtQDP83+4=
-github.com/fbsobreira/gotron-sdk v0.25.3-0.20260320011456-9df99c2a94f4/go.mod h1:EWEP3X7b39Y5WzhodlXRKFZwRfmdYgy/HoC4ic0G9No=
+github.com/fbsobreira/gotron-sdk v0.25.3-0.20260320202924-6eab686352bd h1:km68RiKKjP+7DQOecYwUXL/cIY+sXQDML+d1fiDS9AI=
+github.com/fbsobreira/gotron-sdk v0.25.3-0.20260320202924-6eab686352bd/go.mod h1:MriDda7kzNQrvBfM1qy2kh5Fmdhe23nhaTaObzoxHm0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
@@ -56,8 +56,6 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rjeczalik/notify v0.9.3 h1:6rJAzHTGKXGj76sbRgDiDcYj/HniypXmSJo1SWakZeY=

--- a/internal/resources/knowledge/topics/accounts.md
+++ b/internal/resources/knowledge/topics/accounts.md
@@ -18,8 +18,8 @@ if err != nil || !addr.IsValid() {
     // invalid address
 }
 
-// Convert hex to address (no validation)
-addr := address.HexToAddress("41abc...")
+// Convert hex to address (returns error on invalid hex)
+addr, err := address.HexToAddress("41abc...")
 
 // Convert raw bytes to TRON address (prepends 0x41 for 20-byte input)
 addr = address.BytesToAddress(rawBytes)
@@ -29,7 +29,7 @@ addr, err = address.EthAddressToAddress(ethAddrBytes)
 
 // Other conversions
 addr, err = address.Base64ToAddress(base64String)
-addr = address.BigToAddress(bigInt)
+addr, err = address.BigToAddress(bigInt)  // returns error on oversize big.Int
 addr = address.PubkeyToAddress(ecdsaPubKey)
 
 // Format

--- a/internal/tools/contract_test.go
+++ b/internal/tools/contract_test.go
@@ -70,7 +70,7 @@ func TestStringifyValue_BigInt(t *testing.T) {
 }
 
 func TestStringifyValue_Address(t *testing.T) {
-	addr := address.HexToAddress("410000000000000000000000000000000000000001")
+	addr := address.BytesToAddress([]byte{0x41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	got := stringifyValue(addr)
 	s, ok := got.(string)
 	if !ok {
@@ -83,8 +83,8 @@ func TestStringifyValue_Address(t *testing.T) {
 
 func TestStringifyValue_AddressSlice(t *testing.T) {
 	addrs := []address.Address{
-		address.HexToAddress("410000000000000000000000000000000000000001"),
-		address.HexToAddress("410000000000000000000000000000000000000002"),
+		address.BytesToAddress([]byte{0x41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+		address.BytesToAddress([]byte{0x41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}),
 	}
 	got := stringifyValue(addrs)
 	strs, ok := got.([]string)

--- a/internal/tools/proposal.go
+++ b/internal/tools/proposal.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"slices"
 	"sort"
@@ -58,11 +57,11 @@ func handleListProposals(pool *nodepool.Pool) server.ToolHandlerFunc {
 
 		var list []map[string]any
 		for _, p := range items {
-			proposerAddr := address.HexToAddress(hex.EncodeToString(p.ProposerAddress))
+			proposerAddr := address.BytesToAddress(p.ProposerAddress)
 
 			var approvals []string
 			for _, a := range p.Approvals {
-				addr := address.HexToAddress(hex.EncodeToString(a))
+				addr := address.BytesToAddress(a)
 				approvals = append(approvals, addr.String())
 			}
 

--- a/internal/tools/witness.go
+++ b/internal/tools/witness.go
@@ -58,7 +58,7 @@ func handleListWitnesses(pool *nodepool.Pool) server.ToolHandlerFunc {
 
 		var list []map[string]any
 		for _, w := range witnesses.Witnesses {
-			addr := address.HexToAddress(hex.EncodeToString(w.Address))
+			addr := address.BytesToAddress(w.Address)
 			list = append(list, map[string]any{
 				"address":          addr.String(),
 				"vote_count":       w.VoteCount,


### PR DESCRIPTION
## Summary

Closes #52

Bump gotron-sdk to latest master (v0.25.3-0.20260320202924, PR fbsobreira/gotron-sdk#285) and fix the single breaking change.

**Breaking change:** `address.HexToAddress` now returns `(Address, error)`.

**Fix:** Replace all 5 call sites with `address.BytesToAddress` since the input is always raw protobuf bytes from the node — no hex encoding/decoding roundtrip needed. This is actually cleaner than the original code.

**Files changed:**
- `witness.go` — witness address display
- `proposal.go` — proposer and approval addresses, removed unused `encoding/hex` import
- `contract_test.go` — test addresses use raw byte literals

**Verified non-breaking:** txbuilder single-use, contract error accumulation, keystore changes — all compatible with existing MCP code.

## Test plan

- [x] `make test` with race detector — all pass
- [x] `make build` — compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer patch pseudo-version.
* **Refactor**
  * Simplified internal address handling for more consistent conversion and validation.
* **Documentation**
  * Clarified address-conversion examples and added explicit validity/error handling.
* **Tests**
  * Adjusted tests to construct addresses from raw bytes for more robust validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->