### PR TITLE
refactor: replace direct go-ethereum/crypto with gotron-sdk/pkg/keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/fbsobreira/gotron-mcp
 go 1.25.1
 
 require (
-	github.com/ethereum/go-ethereum v1.17.0
 	github.com/fbsobreira/gotron-sdk v0.25.3-0.20260320202924-6eab686352bd
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/mark3labs/mcp-go v0.45.0
@@ -19,6 +18,7 @@ require (
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
+	github.com/ethereum/go-ethereum v1.17.0 // indirect
 	github.com/fbsobreira/go-bip39 v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect

--- a/internal/wallet/manager.go
+++ b/internal/wallet/manager.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/fbsobreira/gotron-sdk/pkg/keys"
 	"github.com/fbsobreira/gotron-sdk/pkg/keystore"
 	"github.com/fbsobreira/gotron-sdk/pkg/signer"
 	"github.com/fbsobreira/gotron-sdk/pkg/store"
@@ -45,10 +45,11 @@ func (m *Manager) CreateWallet(name string) (string, error) {
 		return "", fmt.Errorf("wallet %q already exists", name)
 	}
 
-	key, err := crypto.GenerateKey()
+	key, err := keys.GenerateKey()
 	if err != nil {
 		return "", fmt.Errorf("generate key: %w", err)
 	}
+	defer keys.ZeroPrivateKey(key)
 
 	ks := m.store.FromAccountName(name)
 	defer func() {
@@ -56,7 +57,7 @@ func (m *Manager) CreateWallet(name string) (string, error) {
 		m.store.Forget(ks)
 	}()
 
-	acct, err := ks.ImportECDSA(key, m.passphrase)
+	acct, err := ks.ImportECDSA(key.ToECDSA(), m.passphrase)
 	if err != nil {
 		return "", fmt.Errorf("import key: %w", err)
 	}


### PR DESCRIPTION
## Summary

Replace the direct `github.com/ethereum/go-ethereum/crypto` import with `github.com/fbsobreira/gotron-sdk/pkg/keys` in the wallet manager.

The SDK already wraps go-ethereum internally — no need to import it directly. Also adds `keys.ZeroPrivateKey()` for proper key material cleanup after keystore import.

**Changes:**
- `internal/wallet/manager.go`: `crypto.GenerateKey()` → `keys.GenerateKey()` + `.ToECDSA()` for keystore import
- Added `defer keys.ZeroPrivateKey(key)` for secure cleanup

## Test plan

- [x] `make test` — all 13 packages pass
- [x] `make build` — compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced security in wallet operations by improving management of sensitive cryptographic keys during creation and import processes, with proper cleanup mechanisms to ensure secure disposal of sensitive material.
  * Refined dependency configuration to optimize system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->