### PR TITLE
feat: add elicitation confirmation and wallet name resolution

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,7 @@ func New(cfg *config.Config, pool *nodepool.Pool) (*server.MCPServer, *wallet.Ma
 		version.Version,
 		server.WithToolCapabilities(false),
 		server.WithResourceCapabilities(false, false),
+		server.WithElicitation(),
 		server.WithInstructions(`GoTRON MCP server for TRON blockchain interaction.
 
 Available capabilities:
@@ -90,8 +91,7 @@ Knowledge base resources available at gotron://knowledge/ for TRON concepts and 
 	tgClient := trongrid.NewClient(cfg.Network, cfg.APIKey)
 	tools.RegisterHistoryTools(s, tgClient)
 
-	// Transaction builders — always available (return unsigned tx hex)
-	tools.RegisterTransferTools(s, pool, trc20Cache)
+	// Transaction builders (non-transfer) — always available
 	tools.RegisterResourceTools(s, pool)
 	tools.RegisterWitnessWriteTools(s, pool)
 	tools.RegisterContractWriteTools(s, pool)
@@ -118,6 +118,9 @@ Knowledge base resources available at gotron://knowledge/ for TRON concepts and 
 			}
 		}
 	}
+
+	// Transfer builders — registered after wallet manager so wallet names resolve in "from"
+	tools.RegisterTransferTools(s, pool, trc20Cache, wm)
 
 	return s, wm, pe
 }

--- a/internal/tools/sign.go
+++ b/internal/tools/sign.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
+	"math/big"
 	"strings"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/fbsobreira/gotron-mcp/internal/wallet"
 	"github.com/fbsobreira/gotron-sdk/pkg/client/transaction"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+	trc20Std "github.com/fbsobreira/gotron-sdk/pkg/standards/trc20"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"google.golang.org/protobuf/proto"
@@ -57,7 +60,7 @@ func RegisterSignTools(s *server.MCPServer, pool *nodepool.Pool, wm *wallet.Mana
 			mcp.WithString("wallet", mcp.Required(), mcp.Description("Wallet name or address")),
 			mcp.WithString("reason", mcp.Description("Reason for this transaction — shown in approval messages")),
 		),
-		handleSignAndBroadcast(pool, wm, pe),
+		handleSignAndBroadcast(s, pool, wm, pe),
 	)
 
 	s.AddTool(
@@ -67,7 +70,7 @@ func RegisterSignTools(s *server.MCPServer, pool *nodepool.Pool, wm *wallet.Mana
 			mcp.WithString("wallet", mcp.Required(), mcp.Description("Wallet name or address")),
 			mcp.WithString("reason", mcp.Description("Reason for this transaction — shown in approval messages")),
 		),
-		handleSignAndConfirm(pool, wm, pe),
+		handleSignAndConfirm(s, pool, wm, pe),
 	)
 
 	// sign_transaction and broadcast_transaction only available when no policy engine
@@ -162,9 +165,9 @@ func handleSignTransaction(wm *wallet.Manager) server.ToolHandlerFunc {
 	}
 }
 
-func handleSignAndBroadcast(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.Engine) server.ToolHandlerFunc {
+func handleSignAndBroadcast(mcpSrv *server.MCPServer, pool *nodepool.Pool, wm *wallet.Manager, pe *policy.Engine) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		progress := newProgressReporter(ctx, req, 4)
+		progress := newProgressReporter(ctx, req, 5)
 		txHex := req.GetString("transaction_hex", "")
 		walletName := wm.ResolveWalletName(req.GetString("wallet", ""))
 
@@ -257,7 +260,18 @@ func handleSignAndBroadcast(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.
 			}
 		}
 
-		progress.Send(3, "Signing with wallet...")
+		// Elicitation confirmation (only when no policy engine)
+		if pe == nil && decoded != nil {
+			progress.Send(3, "Requesting confirmation...")
+			if confirmErr := requestBroadcastConfirmation(ctx, mcpSrv, pool, decoded, walletName); confirmErr != nil {
+				return mcp.NewToolResultJSON(map[string]any{
+					"status": "cancelled",
+					"reason": confirmErr.Error(),
+				})
+			}
+		}
+
+		progress.Send(4, "Signing with wallet...")
 		s, err := wm.GetSigner(walletName)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("sign_and_broadcast: %v", err)), nil
@@ -273,7 +287,7 @@ func handleSignAndBroadcast(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		progress.Send(4, "Broadcasting to network...")
+		progress.Send(5, "Broadcasting to network...")
 		conn := pool.Client()
 		ret, err := conn.BroadcastCtx(ctx, signedTx)
 		if err != nil {
@@ -311,11 +325,11 @@ func handleSignAndBroadcast(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.
 	}
 }
 
-func handleSignAndConfirm(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.Engine) server.ToolHandlerFunc {
+func handleSignAndConfirm(mcpSrv *server.MCPServer, pool *nodepool.Pool, wm *wallet.Manager, pe *policy.Engine) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		const maxConfirmAttempts = 20
-		// 4 setup steps + polling attempts + 1 confirmation step
-		progress := newProgressReporter(ctx, req, 5+maxConfirmAttempts)
+		// 5 setup steps + polling attempts + 1 confirmation step
+		progress := newProgressReporter(ctx, req, 6+maxConfirmAttempts)
 
 		txHex := req.GetString("transaction_hex", "")
 		walletName := wm.ResolveWalletName(req.GetString("wallet", ""))
@@ -404,7 +418,18 @@ func handleSignAndConfirm(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.En
 			}
 		}
 
-		progress.Send(3, "Signing with wallet...")
+		// Elicitation confirmation (only when no policy engine)
+		if pe == nil && decoded != nil {
+			progress.Send(3, "Requesting confirmation...")
+			if confirmErr := requestBroadcastConfirmation(ctx, mcpSrv, pool, decoded, walletName); confirmErr != nil {
+				return mcp.NewToolResultJSON(map[string]any{
+					"status": "cancelled",
+					"reason": confirmErr.Error(),
+				})
+			}
+		}
+
+		progress.Send(4, "Signing with wallet...")
 		s, err := wm.GetSigner(walletName)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("sign_and_confirm: %v", err)), nil
@@ -420,7 +445,7 @@ func handleSignAndConfirm(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.En
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		progress.Send(4, "Broadcasting to network...")
+		progress.Send(5, "Broadcasting to network...")
 		conn := pool.Client()
 		ret, err := conn.BroadcastCtx(ctx, signedTx)
 		if err != nil {
@@ -451,7 +476,7 @@ func handleSignAndConfirm(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.En
 			case <-ticker.C:
 			}
 
-			progress.Send(5+attempt, fmt.Sprintf("Waiting for confirmation (attempt %d/%d)...", attempt+1, maxConfirmAttempts))
+			progress.Send(6+attempt, fmt.Sprintf("Waiting for confirmation (attempt %d/%d)...", attempt+1, maxConfirmAttempts))
 
 			info, infoErr := conn.GetTransactionInfoByIDCtx(ctx, txid)
 			if infoErr != nil {
@@ -461,7 +486,7 @@ func handleSignAndConfirm(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.En
 				return mcp.NewToolResultError(fmt.Sprintf("sign_and_confirm: %v", infoErr)), nil
 			}
 			if info != nil && info.BlockNumber > 0 {
-				progress.Send(5+maxConfirmAttempts, fmt.Sprintf("Confirmed in block %d", info.BlockNumber))
+				progress.Send(6+maxConfirmAttempts, fmt.Sprintf("Confirmed in block %d", info.BlockNumber))
 				return mcp.NewToolResultJSON(map[string]any{
 					"txid":           txid,
 					"success":        info.GetResult() != core.TransactionInfo_FAILED,
@@ -527,6 +552,139 @@ func rebuildTransaction(ctx context.Context, pool *nodepool.Pool, intent *policy
 		return nil, fmt.Errorf("rebuilding transfer: %w", err)
 	}
 	return ext.Transaction, nil
+}
+
+// formatTokenAmount formats a raw big.Int token amount with decimal point insertion.
+// For example, formatTokenAmount(big.NewInt(1000000), 6) returns "1.000000".
+func formatTokenAmount(raw *big.Int, decimals int) string {
+	if raw == nil {
+		return "0"
+	}
+	s := raw.String()
+	if decimals <= 0 {
+		return s
+	}
+	// Pad with leading zeros if needed
+	for len(s) <= decimals {
+		s = "0" + s
+	}
+	intPart := s[:len(s)-decimals]
+	fracPart := s[len(s)-decimals:]
+	// Trim trailing zeros from fractional part for cleaner display
+	fracPart = strings.TrimRight(fracPart, "0")
+	if fracPart == "" {
+		return intPart
+	}
+	return intPart + "." + fracPart
+}
+
+// requestBroadcastConfirmation asks the user to confirm a transaction before broadcast
+// via MCP elicitation. Returns nil to proceed, or an error to cancel.
+// Gracefully skips if the client doesn't support elicitation or decoded is nil.
+func requestBroadcastConfirmation(
+	ctx context.Context,
+	s *server.MCPServer,
+	pool *nodepool.Pool,
+	decoded *transaction.ContractData,
+	walletName string,
+) error {
+	if decoded == nil || s == nil {
+		return nil
+	}
+
+	// Build human-readable confirmation message from decoded contract fields.
+	// For TRC20 transfers, decode ABI data and resolve decimals for human-readable amounts.
+	var msg strings.Builder
+	msg.WriteString("Confirm transaction before broadcast:\n\n")
+	fmt.Fprintf(&msg, "Type: %s\n", decoded.Type)
+	if from, ok := decoded.Fields["owner_address"]; ok {
+		fmt.Fprintf(&msg, "From: %v (wallet: %q)\n", from, walletName)
+	}
+
+	// Try to decode TRC20 transfer details from ABI data
+	trc20Decoded := false
+	if decoded.Type == "TriggerSmartContract" {
+		if intent, err := policy.IntentFromContractData(walletName, decoded); err == nil && intent.TokenID != "TRX" {
+			fmt.Fprintf(&msg, "To: %s\n", intent.ToAddr)
+			fmt.Fprintf(&msg, "Token contract: %s\n", intent.TokenID)
+			// Try to resolve token decimals and symbol for human-readable display
+			if pool != nil {
+				token := trc20Std.New(pool.Client(), intent.TokenID)
+				if symbol, sErr := token.Symbol(ctx); sErr == nil {
+					if decimals, dErr := token.Decimals(ctx); dErr == nil && decimals > 0 && intent.RawTokenAmt != nil {
+						// Use big.Int string with decimal point insertion for exact precision
+						fmt.Fprintf(&msg, "Amount: %s %s\n", formatTokenAmount(intent.RawTokenAmt, int(decimals)), symbol)
+					} else if intent.RawTokenAmt != nil {
+						fmt.Fprintf(&msg, "Amount: %s raw units (%s)\n", intent.RawTokenAmt.String(), symbol)
+					} else {
+						fmt.Fprintf(&msg, "Amount: %.0f raw units (%s)\n", intent.TokenAmount, symbol)
+					}
+				} else if intent.RawTokenAmt != nil {
+					fmt.Fprintf(&msg, "Amount: %s raw units\n", intent.RawTokenAmt.String())
+				} else {
+					fmt.Fprintf(&msg, "Amount: %.0f raw units\n", intent.TokenAmount)
+				}
+			} else if intent.RawTokenAmt != nil {
+				fmt.Fprintf(&msg, "Amount: %s raw units\n", intent.RawTokenAmt.String())
+			} else {
+				fmt.Fprintf(&msg, "Amount: %.0f raw units\n", intent.TokenAmount)
+			}
+			trc20Decoded = true
+		}
+	}
+
+	if !trc20Decoded {
+		if to, ok := decoded.Fields["to_address"]; ok {
+			fmt.Fprintf(&msg, "To: %v\n", to)
+		}
+		if contract, ok := decoded.Fields["contract_address"]; ok {
+			fmt.Fprintf(&msg, "Contract: %v\n", contract)
+		}
+		if amount, ok := decoded.Fields["amount"]; ok {
+			switch v := amount.(type) {
+			case string:
+				// TransferContract: SDK already converts to human-readable TRX string
+				fmt.Fprintf(&msg, "Amount: %s TRX\n", v)
+			case int64:
+				// TransferAssetContract (TRC10): raw units
+				fmt.Fprintf(&msg, "Amount: %d (raw units)\n", v)
+			case float64:
+				fmt.Fprintf(&msg, "Amount: %g (raw units)\n", v)
+			default:
+				fmt.Fprintf(&msg, "Amount: %v\n", amount)
+			}
+		}
+		if callValue, ok := decoded.Fields["call_value"]; ok {
+			// SDK converts call_value via sunToTRX() — returns string
+			if cv, isStr := callValue.(string); isStr && cv != "" && cv != "0.000000" {
+				fmt.Fprintf(&msg, "Call Value: %s TRX\n", cv)
+			}
+		}
+	}
+
+	elicitReq := mcp.ElicitationRequest{
+		Params: mcp.ElicitationParams{
+			Message: msg.String(),
+			RequestedSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+	}
+
+	result, err := s.RequestElicitation(ctx, elicitReq)
+	if err != nil {
+		if errors.Is(err, server.ErrElicitationNotSupported) || errors.Is(err, server.ErrNoActiveSession) {
+			return nil
+		}
+		return fmt.Errorf("transaction broadcast cancelled: %w", err)
+	}
+
+	if result.Action == mcp.ElicitationResponseActionAccept {
+		return nil
+	}
+
+	return fmt.Errorf("transaction broadcast cancelled by user")
 }
 
 func handleRequestLimitOverride(pool *nodepool.Pool, wm *wallet.Manager, pe *policy.Engine) server.ToolHandlerFunc {

--- a/internal/tools/sign_test.go
+++ b/internal/tools/sign_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -13,10 +14,12 @@ import (
 	"github.com/fbsobreira/gotron-mcp/internal/nodepool"
 	"github.com/fbsobreira/gotron-mcp/internal/policy"
 	"github.com/fbsobreira/gotron-mcp/internal/wallet"
+	"github.com/fbsobreira/gotron-sdk/pkg/client/transaction"
 	"github.com/fbsobreira/gotron-sdk/pkg/keystore"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -149,7 +152,7 @@ func TestSignTransaction_Success(t *testing.T) {
 
 func TestSignAndBroadcast_InvalidHex(t *testing.T) {
 	wm, pool := newTestSignSetup(t, &mockWalletServer{})
-	result := callTool(t, handleSignAndBroadcast(pool, wm, nil), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, nil), map[string]any{
 		"transaction_hex": "not-hex",
 		"wallet":          "test",
 	})
@@ -159,7 +162,7 @@ func TestSignAndBroadcast_InvalidHex(t *testing.T) {
 func TestSignAndBroadcast_WalletNotFound(t *testing.T) {
 	wm, pool := newTestSignSetup(t, &mockWalletServer{})
 	txHex := buildTestTxHex(t)
-	result := callTool(t, handleSignAndBroadcast(pool, wm, nil), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, nil), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "nonexistent",
 	})
@@ -182,7 +185,7 @@ func TestSignAndBroadcast_Success(t *testing.T) {
 	require.NoError(t, err, "CreateWallet")
 
 	txHex := buildTestTxHex(t)
-	result := callTool(t, handleSignAndBroadcast(pool, wm, nil), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, nil), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "broadcast-signer",
 	})
@@ -223,7 +226,7 @@ func TestSignAndConfirm_Success(t *testing.T) {
 	require.NoError(t, err, "CreateWallet")
 
 	txHex := buildTestTxHex(t)
-	result := callTool(t, handleSignAndConfirm(pool, wm, nil), map[string]any{
+	result := callTool(t, handleSignAndConfirm(nil, pool, wm, nil), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "confirm-signer",
 	})
@@ -292,7 +295,7 @@ func TestSignAndBroadcast_BroadcastFails(t *testing.T) {
 	_, err := wm.CreateWallet("test-wallet")
 	require.NoError(t, err, "CreateWallet")
 	txHex := buildTestTxHex(t)
-	result := callTool(t, handleSignAndBroadcast(pool, wm, nil), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, nil), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "test-wallet",
 	})
@@ -313,7 +316,7 @@ func TestSignAndBroadcast_BroadcastRejected(t *testing.T) {
 	_, err := wm.CreateWallet("test-wallet")
 	require.NoError(t, err, "CreateWallet")
 	txHex := buildTestTxHex(t)
-	result := callTool(t, handleSignAndBroadcast(pool, wm, nil), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, nil), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "test-wallet",
 	})
@@ -344,7 +347,7 @@ func TestSignAndConfirm_ContextCancelled(t *testing.T) {
 		"transaction_hex": txHex,
 		"wallet":          "test-wallet",
 	}
-	handler := handleSignAndConfirm(pool, wm, nil)
+	handler := handleSignAndConfirm(nil, pool, wm, nil)
 	result, goErr := handler(ctx, req)
 	require.NoError(t, goErr, "handler returned Go error")
 	assert.True(t, result.IsError, "expected error for cancelled context")
@@ -363,7 +366,7 @@ func TestSignAndConfirm_RPCError(t *testing.T) {
 	_, err := wm.CreateWallet("test-wallet")
 	require.NoError(t, err, "CreateWallet")
 	txHex := buildTestTxHex(t)
-	result := callTool(t, handleSignAndConfirm(pool, wm, nil), map[string]any{
+	result := callTool(t, handleSignAndConfirm(nil, pool, wm, nil), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "test-wallet",
 	})
@@ -548,7 +551,7 @@ func TestSignAndBroadcast_PolicyDenied_ReturnsHint(t *testing.T) {
 		5_000_000,
 	)
 
-	result := callTool(t, handleSignAndBroadcast(pool, wm, pe), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, pe), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "hot-wallet",
 	})
@@ -721,7 +724,7 @@ func TestSignAndBroadcast_ApprovalFlow_Approved(t *testing.T) {
 		10_000_000,
 	)
 
-	result := callTool(t, handleSignAndBroadcast(pool, wm, pe), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, pe), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "hot-wallet",
 		"reason":          "test approval flow",
@@ -758,7 +761,7 @@ func TestSignAndBroadcast_ApprovalFlow_Rejected(t *testing.T) {
 		10_000_000,
 	)
 
-	result := callTool(t, handleSignAndBroadcast(pool, wm, pe), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, pe), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "hot-wallet",
 		"reason":          "test rejection",
@@ -792,7 +795,7 @@ func TestSignAndBroadcast_NoApprover_ReturnsHint(t *testing.T) {
 		10_000_000,
 	)
 
-	result := callTool(t, handleSignAndBroadcast(pool, wm, pe), map[string]any{
+	result := callTool(t, handleSignAndBroadcast(nil, pool, wm, pe), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "hot-wallet",
 	})
@@ -830,7 +833,7 @@ func TestSignAndConfirm_PolicyDenied_ReturnsHint(t *testing.T) {
 		5_000_000,
 	)
 
-	result := callTool(t, handleSignAndConfirm(pool, wm, pe), map[string]any{
+	result := callTool(t, handleSignAndConfirm(nil, pool, wm, pe), map[string]any{
 		"transaction_hex": txHex,
 		"wallet":          "hot-wallet",
 	})
@@ -1024,4 +1027,497 @@ func TestRebuildTransaction_InvalidAddress(t *testing.T) {
 	_, err := rebuildTransaction(context.Background(), pool, intent)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid from address")
+}
+
+// mockBasicSession implements server.ClientSession but NOT SessionWithElicitation.
+type mockBasicSession struct{ id string }
+
+func (m *mockBasicSession) SessionID() string { return m.id }
+func (m *mockBasicSession) NotificationChannel() chan<- mcp.JSONRPCNotification {
+	return make(chan mcp.JSONRPCNotification, 1)
+}
+func (m *mockBasicSession) Initialize()       {}
+func (m *mockBasicSession) Initialized() bool { return true }
+
+// mockElicitSession implements server.SessionWithElicitation for testing.
+type mockElicitSession struct {
+	id     string
+	result *mcp.ElicitationResult
+	err    error
+}
+
+func (m *mockElicitSession) SessionID() string { return m.id }
+func (m *mockElicitSession) NotificationChannel() chan<- mcp.JSONRPCNotification {
+	return make(chan mcp.JSONRPCNotification, 1)
+}
+func (m *mockElicitSession) Initialize()       {}
+func (m *mockElicitSession) Initialized() bool { return true }
+func (m *mockElicitSession) RequestElicitation(_ context.Context, _ mcp.ElicitationRequest) (*mcp.ElicitationResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.result, nil
+}
+
+// --- Elicitation full flow tests ---
+
+// callToolWithCtx invokes a handler with a custom context (for session injection).
+func callToolWithCtx(t *testing.T, ctx context.Context, handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error), args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	result, err := handler(ctx, req)
+	if err != nil {
+		t.Fatalf("handler returned Go error (not tool error): %v", err)
+	}
+	return result
+}
+
+func TestSignAndBroadcast_Elicitation_Confirmed(t *testing.T) {
+	mock := &mockWalletServer{
+		BroadcastTransactionFunc: func(_ context.Context, _ *core.Transaction) (*api.Return, error) {
+			return &api.Return{Result: true, Code: api.Return_SUCCESS, Message: []byte("ok")}, nil
+		},
+	}
+	wm, pool := newTestSignSetup(t, mock)
+	_, err := wm.CreateWallet("elicit-signer")
+	require.NoError(t, err)
+
+	mcpSrv := server.NewMCPServer("test", "1.0.0", server.WithElicitation())
+	session := &mockElicitSession{
+		id: "confirm-session",
+		result: &mcp.ElicitationResult{
+			ElicitationResponse: mcp.ElicitationResponse{
+				Action: mcp.ElicitationResponseActionAccept,
+			},
+		},
+	}
+	ctx := mcpSrv.WithContext(context.Background(), session)
+
+	txHex := buildTransferTxHex(t,
+		"TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		1_000_000,
+	)
+
+	handler := handleSignAndBroadcast(mcpSrv, pool, wm, nil) // pe=nil triggers elicitation
+	result := callToolWithCtx(t, ctx, handler, map[string]any{
+		"transaction_hex": txHex,
+		"wallet":          "elicit-signer",
+	})
+	require.False(t, result.IsError, "expected success after user confirmation, got: %v", result.Content)
+
+	data := parseJSONResult(t, result)
+	assert.Equal(t, true, data["success"])
+	assert.NotEmpty(t, data["txid"])
+}
+
+func TestSignAndBroadcast_Elicitation_Declined(t *testing.T) {
+	mock := &mockWalletServer{}
+	wm, pool := newTestSignSetup(t, mock)
+	_, err := wm.CreateWallet("elicit-signer")
+	require.NoError(t, err)
+
+	mcpSrv := server.NewMCPServer("test", "1.0.0", server.WithElicitation())
+	session := &mockElicitSession{
+		id: "decline-session",
+		result: &mcp.ElicitationResult{
+			ElicitationResponse: mcp.ElicitationResponse{
+				Action: mcp.ElicitationResponseActionDecline,
+			},
+		},
+	}
+	ctx := mcpSrv.WithContext(context.Background(), session)
+
+	txHex := buildTransferTxHex(t,
+		"TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		1_000_000,
+	)
+
+	handler := handleSignAndBroadcast(mcpSrv, pool, wm, nil)
+	result := callToolWithCtx(t, ctx, handler, map[string]any{
+		"transaction_hex": txHex,
+		"wallet":          "elicit-signer",
+	})
+	require.False(t, result.IsError, "expected JSON result, not tool error")
+
+	data := parseJSONResult(t, result)
+	assert.Equal(t, "cancelled", data["status"])
+	assert.Contains(t, data["reason"], "cancelled by user")
+}
+
+func TestSignAndBroadcast_Elicitation_NotSupported_Proceeds(t *testing.T) {
+	mock := &mockWalletServer{
+		BroadcastTransactionFunc: func(_ context.Context, _ *core.Transaction) (*api.Return, error) {
+			return &api.Return{Result: true, Code: api.Return_SUCCESS, Message: []byte("ok")}, nil
+		},
+	}
+	wm, pool := newTestSignSetup(t, mock)
+	_, err := wm.CreateWallet("elicit-signer")
+	require.NoError(t, err)
+
+	// Use a session that does NOT support elicitation — should proceed without confirmation
+	mcpSrv := server.NewMCPServer("test", "1.0.0", server.WithElicitation())
+	session := &mockBasicSession{id: "no-elicit"}
+	ctx := mcpSrv.WithContext(context.Background(), session)
+
+	txHex := buildTransferTxHex(t,
+		"TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		1_000_000,
+	)
+
+	handler := handleSignAndBroadcast(mcpSrv, pool, wm, nil)
+	result := callToolWithCtx(t, ctx, handler, map[string]any{
+		"transaction_hex": txHex,
+		"wallet":          "elicit-signer",
+	})
+	require.False(t, result.IsError, "expected success when elicitation not supported, got: %v", result.Content)
+
+	data := parseJSONResult(t, result)
+	assert.Equal(t, true, data["success"], "should broadcast normally when elicitation unsupported")
+}
+
+func TestSignAndBroadcast_WithPolicy_SkipsElicitation(t *testing.T) {
+	mock := &mockWalletServer{
+		BroadcastTransactionFunc: func(_ context.Context, _ *core.Transaction) (*api.Return, error) {
+			return &api.Return{Result: true, Code: api.Return_SUCCESS, Message: []byte("ok")}, nil
+		},
+	}
+	wm, pool := newTestSignSetup(t, mock)
+	_, err := wm.CreateWallet("policy-wallet")
+	require.NoError(t, err)
+
+	cfg := &policy.Config{
+		Enabled: true,
+		Wallets: map[string]*policy.WalletPolicy{
+			"policy-wallet": {PerTxLimitTRX: 1000},
+		},
+	}
+	pe := newTestPolicyEngine(t, cfg)
+
+	// Session that would decline — but policy is active so elicitation should be skipped
+	mcpSrv := server.NewMCPServer("test", "1.0.0", server.WithElicitation())
+	session := &mockElicitSession{
+		id: "should-not-be-called",
+		result: &mcp.ElicitationResult{
+			ElicitationResponse: mcp.ElicitationResponse{
+				Action: mcp.ElicitationResponseActionDecline,
+			},
+		},
+	}
+	ctx := mcpSrv.WithContext(context.Background(), session)
+
+	txHex := buildTransferTxHex(t,
+		"TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		1_000_000,
+	)
+
+	handler := handleSignAndBroadcast(mcpSrv, pool, wm, pe)
+	result := callToolWithCtx(t, ctx, handler, map[string]any{
+		"transaction_hex": txHex,
+		"wallet":          "policy-wallet",
+	})
+	require.False(t, result.IsError, "expected success — policy active means no elicitation, got: %v", result.Content)
+
+	data := parseJSONResult(t, result)
+	assert.Equal(t, true, data["success"], "should broadcast without elicitation when policy is active")
+}
+
+func TestSignAndConfirm_Elicitation_Declined(t *testing.T) {
+	mock := &mockWalletServer{}
+	wm, pool := newTestSignSetup(t, mock)
+	_, err := wm.CreateWallet("elicit-signer")
+	require.NoError(t, err)
+
+	mcpSrv := server.NewMCPServer("test", "1.0.0", server.WithElicitation())
+	session := &mockElicitSession{
+		id: "decline-confirm",
+		result: &mcp.ElicitationResult{
+			ElicitationResponse: mcp.ElicitationResponse{
+				Action: mcp.ElicitationResponseActionDecline,
+			},
+		},
+	}
+	ctx := mcpSrv.WithContext(context.Background(), session)
+
+	txHex := buildTransferTxHex(t,
+		"TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		1_000_000,
+	)
+
+	handler := handleSignAndConfirm(mcpSrv, pool, wm, nil)
+	result := callToolWithCtx(t, ctx, handler, map[string]any{
+		"transaction_hex": txHex,
+		"wallet":          "elicit-signer",
+	})
+	require.False(t, result.IsError, "expected JSON result")
+
+	data := parseJSONResult(t, result)
+	assert.Equal(t, "cancelled", data["status"])
+	assert.Contains(t, data["reason"], "cancelled by user")
+}
+
+func TestSignAndConfirm_Elicitation_Confirmed(t *testing.T) {
+	mock := &mockWalletServer{
+		BroadcastTransactionFunc: func(_ context.Context, _ *core.Transaction) (*api.Return, error) {
+			return &api.Return{Result: true, Code: api.Return_SUCCESS, Message: []byte("ok")}, nil
+		},
+		GetTransactionInfoByIdFunc: func(_ context.Context, msg *api.BytesMessage) (*core.TransactionInfo, error) {
+			return &core.TransactionInfo{
+				Id:          msg.Value,
+				BlockNumber: 99999,
+				Fee:         50000,
+				Receipt:     &core.ResourceReceipt{EnergyUsageTotal: 10000, NetUsage: 200},
+			}, nil
+		},
+	}
+	wm, pool := newTestSignSetup(t, mock)
+	_, err := wm.CreateWallet("elicit-signer")
+	require.NoError(t, err)
+
+	mcpSrv := server.NewMCPServer("test", "1.0.0", server.WithElicitation())
+	session := &mockElicitSession{
+		id: "confirm-session",
+		result: &mcp.ElicitationResult{
+			ElicitationResponse: mcp.ElicitationResponse{
+				Action: mcp.ElicitationResponseActionAccept,
+			},
+		},
+	}
+	ctx := mcpSrv.WithContext(context.Background(), session)
+
+	txHex := buildTransferTxHex(t,
+		"TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
+		"TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+		1_000_000,
+	)
+
+	handler := handleSignAndConfirm(mcpSrv, pool, wm, nil)
+	result := callToolWithCtx(t, ctx, handler, map[string]any{
+		"transaction_hex": txHex,
+		"wallet":          "elicit-signer",
+	})
+	require.False(t, result.IsError, "expected success after confirmation, got: %v", result.Content)
+
+	data := parseJSONResult(t, result)
+	assert.Equal(t, true, data["confirmed"])
+	assert.NotEmpty(t, data["txid"])
+}
+
+// --- formatTokenAmount tests ---
+
+func TestFormatTokenAmount(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      *big.Int
+		decimals int
+		want     string
+	}{
+		{"nil", nil, 6, "0"},
+		{"zero decimals", big.NewInt(42), 0, "42"},
+		{"1 USDT (6 decimals)", big.NewInt(1_000_000), 6, "1"},
+		{"10.5 USDT", big.NewInt(10_500_000), 6, "10.5"},
+		{"0.000001 USDT", big.NewInt(1), 6, "0.000001"},
+		{"large 18-decimal token", new(big.Int).SetUint64(1_000_000_000_000_000_000), 18, "1"},
+		{"fractional 18-decimal", big.NewInt(123_456_789_012_345_678), 18, "0.123456789012345678"},
+		{"negative decimals", big.NewInt(100), -1, "100"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatTokenAmount(tt.raw, tt.decimals)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// --- requestBroadcastConfirmation message building tests ---
+
+func TestRequestBroadcastConfirmation_MessageVariants(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0", server.WithElicitation())
+	acceptSession := &mockElicitSession{
+		id: "msg-test",
+		result: &mcp.ElicitationResult{
+			ElicitationResponse: mcp.ElicitationResponse{
+				Action: mcp.ElicitationResponseActionAccept,
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		decoded *transaction.ContractData
+	}{
+		{
+			name: "TransferContract with string amount",
+			decoded: &transaction.ContractData{
+				Type:   "TransferContract",
+				Fields: map[string]any{"owner_address": "TAddr1", "to_address": "TAddr2", "amount": "100.000000"},
+			},
+		},
+		{
+			name: "TransferContract with int64 amount (TRC10)",
+			decoded: &transaction.ContractData{
+				Type:   "TransferAssetContract",
+				Fields: map[string]any{"owner_address": "TAddr1", "to_address": "TAddr2", "amount": int64(5000)},
+			},
+		},
+		{
+			name: "TransferContract with float64 amount",
+			decoded: &transaction.ContractData{
+				Type:   "TransferContract",
+				Fields: map[string]any{"owner_address": "TAddr1", "to_address": "TAddr2", "amount": float64(42)},
+			},
+		},
+		{
+			name: "TriggerSmartContract with contract_address",
+			decoded: &transaction.ContractData{
+				Type:   "TriggerSmartContract",
+				Fields: map[string]any{"owner_address": "TAddr1", "contract_address": "TContract", "data": "abcd", "call_value": "0.000000"},
+			},
+		},
+		{
+			name: "TriggerSmartContract with call_value",
+			decoded: &transaction.ContractData{
+				Type:   "TriggerSmartContract",
+				Fields: map[string]any{"owner_address": "TAddr1", "contract_address": "TContract", "data": "abcd", "call_value": "5.000000"},
+			},
+		},
+		{
+			name: "minimal decoded data",
+			decoded: &transaction.ContractData{
+				Type:   "UnknownContract",
+				Fields: map[string]any{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := mcpSrv.WithContext(context.Background(), acceptSession)
+			err := requestBroadcastConfirmation(ctx, mcpSrv, nil, tt.decoded, "test-wallet")
+			assert.NoError(t, err, "all message variants should proceed on Accept")
+		})
+	}
+}
+
+func TestRequestBroadcastConfirmation_ElicitationError(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0", server.WithElicitation())
+	errSession := &mockElicitSession{
+		id:  "err-session",
+		err: fmt.Errorf("unexpected elicitation error"),
+	}
+	ctx := mcpSrv.WithContext(context.Background(), errSession)
+
+	decoded := &transaction.ContractData{
+		Type:   "TransferContract",
+		Fields: map[string]any{"owner_address": "TAddr1", "to_address": "TAddr2", "amount": "1.000000"},
+	}
+
+	err := requestBroadcastConfirmation(ctx, mcpSrv, nil, decoded, "test-wallet")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+}
+
+// --- requestBroadcastConfirmation unit tests ---
+
+func TestRequestBroadcastConfirmation(t *testing.T) {
+	decoded := &transaction.ContractData{
+		Type:   "TransferContract",
+		Fields: map[string]any{"owner_address": "TAddr1", "to_address": "TAddr2", "amount": 100.0},
+	}
+
+	tests := []struct {
+		name      string
+		decoded   *transaction.ContractData
+		srv       *server.MCPServer
+		session   server.ClientSession
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "nil decoded skips confirmation",
+			decoded: nil,
+			srv:     nil,
+			session: nil,
+			wantErr: false,
+		},
+		{
+			name:    "nil server skips confirmation",
+			decoded: decoded,
+			srv:     nil,
+			session: nil,
+			wantErr: false,
+		},
+		{
+			name:    "accept proceeds",
+			decoded: decoded,
+			srv:     server.NewMCPServer("test", "1.0.0", server.WithElicitation()),
+			session: &mockElicitSession{
+				id: "accept",
+				result: &mcp.ElicitationResult{
+					ElicitationResponse: mcp.ElicitationResponse{
+						Action: mcp.ElicitationResponseActionAccept,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "decline cancels",
+			decoded: decoded,
+			srv:     server.NewMCPServer("test", "1.0.0", server.WithElicitation()),
+			session: &mockElicitSession{
+				id: "decline",
+				result: &mcp.ElicitationResult{
+					ElicitationResponse: mcp.ElicitationResponse{
+						Action: mcp.ElicitationResponseActionDecline,
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "cancelled by user",
+		},
+		{
+			name:    "cancel cancels",
+			decoded: decoded,
+			srv:     server.NewMCPServer("test", "1.0.0", server.WithElicitation()),
+			session: &mockElicitSession{
+				id: "cancel",
+				result: &mcp.ElicitationResult{
+					ElicitationResponse: mcp.ElicitationResponse{
+						Action: mcp.ElicitationResponseActionCancel,
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "cancelled by user",
+		},
+		{
+			name:    "session without elicitation support degrades gracefully",
+			decoded: decoded,
+			srv:     server.NewMCPServer("test", "1.0.0", server.WithElicitation()),
+			session: &mockBasicSession{id: "basic"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.srv != nil && tt.session != nil {
+				ctx = tt.srv.WithContext(ctx, tt.session)
+			}
+			err := requestBroadcastConfirmation(ctx, tt.srv, nil, tt.decoded, "test-wallet")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/tools/token.go
+++ b/internal/tools/token.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fbsobreira/gotron-mcp/internal/nodepool"
 	"github.com/fbsobreira/gotron-mcp/internal/retry"
 	"github.com/fbsobreira/gotron-mcp/internal/util"
+	"github.com/fbsobreira/gotron-mcp/internal/wallet"
 	"github.com/fbsobreira/gotron-sdk/pkg/contract"
 	"github.com/fbsobreira/gotron-sdk/pkg/standards/trc20"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -189,17 +190,18 @@ func handleEstimateTRC20Energy(pool *nodepool.Pool, cache *trc20.MetadataCache) 
 }
 
 // handleTransferTRC20 builds an unsigned TRC20 transfer using the shared trc20Token helper.
-func handleTransferTRC20(pool *nodepool.Pool, cache *trc20.MetadataCache) server.ToolHandlerFunc {
+func handleTransferTRC20(pool *nodepool.Pool, cache *trc20.MetadataCache, wm *wallet.Manager) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		from := req.GetString("from", "")
+		fromInput := req.GetString("from", "")
 		to := req.GetString("to", "")
 		contractAddr := req.GetString("contract_address", "")
 		amountStr := req.GetString("amount", "")
 		feeLimit := req.GetInt("fee_limit", 100)
 		conn := pool.Client()
 
-		if err := validateAddress(from); err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
+		from, err := resolveFromAddress(wm, fromInput)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("transfer_trc20: %v", err)), nil
 		}
 		if err := validateAddress(to); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid to address: %v", err)), nil

--- a/internal/tools/transfer.go
+++ b/internal/tools/transfer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fbsobreira/gotron-mcp/internal/nodepool"
 	"github.com/fbsobreira/gotron-mcp/internal/util"
+	"github.com/fbsobreira/gotron-mcp/internal/wallet"
 	"github.com/fbsobreira/gotron-sdk/pkg/standards/trc20"
 	"github.com/fbsobreira/gotron-sdk/pkg/txbuilder"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -14,44 +15,72 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// RegisterTransferTools registers transfer_trx and transfer_trc20 (local mode only).
+// resolveFromAddress resolves a wallet name or address to a base58 address.
+// If wm is available, tries wallet name lookup first. Returns a clear error
+// hint if the input is neither a valid address nor a known wallet name.
+func resolveFromAddress(wm *wallet.Manager, nameOrAddr string) (string, error) {
+	if wm != nil {
+		if addr, err := wm.ResolveAddress(nameOrAddr); err == nil {
+			if vErr := validateAddress(addr); vErr == nil {
+				return addr, nil
+			}
+		}
+	}
+	if err := validateAddress(nameOrAddr); err != nil {
+		if wm != nil {
+			return "", fmt.Errorf("invalid from: %q is not a valid TRON address or known wallet name — use list_wallets to find the address", nameOrAddr)
+		}
+		return "", fmt.Errorf("invalid from address: %v", err)
+	}
+	return nameOrAddr, nil
+}
+
+// RegisterTransferTools registers transfer_trx and transfer_trc20.
+// The wallet manager is optional — when provided, allows using wallet names in the "from" field.
 // The cache is shared with RegisterTokenTools for TRC20 metadata caching.
-func RegisterTransferTools(s *server.MCPServer, pool *nodepool.Pool, cache *trc20.MetadataCache) {
+func RegisterTransferTools(s *server.MCPServer, pool *nodepool.Pool, cache *trc20.MetadataCache, wm ...*wallet.Manager) {
+	var walletMgr *wallet.Manager
+	if len(wm) > 0 {
+		walletMgr = wm[0]
+	}
+
+	fromDesc := "Sender address (base58) or wallet name"
 	s.AddTool(
 		mcp.NewTool("transfer_trx",
 			mcp.WithDescription("Create an unsigned TRX transfer transaction. Returns transaction hex for signing."),
-			mcp.WithString("from", mcp.Required(), mcp.Description("Sender address (base58, starts with T)")),
+			mcp.WithString("from", mcp.Required(), mcp.Description(fromDesc)),
 			mcp.WithString("to", mcp.Required(), mcp.Description("Recipient address (base58, starts with T)")),
 			mcp.WithString("amount", mcp.Required(), mcp.Description("Amount in TRX (e.g., '100.5')")),
 			mcp.WithString("memo", mcp.Description("Optional memo to attach to the transaction")),
 			mcp.WithNumber("permission_id", mcp.Description("Permission ID for multi-sig transactions")),
 		),
-		handleTransferTRX(pool),
+		handleTransferTRX(pool, walletMgr),
 	)
 
 	s.AddTool(
 		mcp.NewTool("transfer_trc20",
 			mcp.WithDescription("Create an unsigned TRC20 token transfer transaction. Returns transaction hex for signing."),
-			mcp.WithString("from", mcp.Required(), mcp.Description("Sender address (base58, starts with T)")),
+			mcp.WithString("from", mcp.Required(), mcp.Description(fromDesc)),
 			mcp.WithString("to", mcp.Required(), mcp.Description("Recipient address (base58, starts with T)")),
 			mcp.WithString("contract_address", mcp.Required(), mcp.Description("TRC20 contract address (base58, starts with T)")),
 			mcp.WithString("amount", mcp.Required(), mcp.Description("Amount in token units (human-readable, e.g., '100.5')")),
 			mcp.WithNumber("fee_limit", mcp.Description("Fee limit in TRX, range 0-15000 (default: 100)")),
 			mcp.WithNumber("permission_id", mcp.Description("Permission ID for multi-sig transactions")),
 		),
-		handleTransferTRC20(pool, cache),
+		handleTransferTRC20(pool, cache, walletMgr),
 	)
 }
 
-func handleTransferTRX(pool *nodepool.Pool) server.ToolHandlerFunc {
+func handleTransferTRX(pool *nodepool.Pool, wm *wallet.Manager) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		from := req.GetString("from", "")
+		fromInput := req.GetString("from", "")
 		to := req.GetString("to", "")
 		amountStr := req.GetString("amount", "")
 		conn := pool.Client()
 
-		if err := validateAddress(from); err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("invalid from address: %v", err)), nil
+		from, err := resolveFromAddress(wm, fromInput)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("transfer_trx: %v", err)), nil
 		}
 		if err := validateAddress(to); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid to address: %v", err)), nil

--- a/internal/tools/transfer_test.go
+++ b/internal/tools/transfer_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/fbsobreira/gotron-mcp/internal/wallet"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ import (
 
 func TestTransferTRX_InvalidFromAddress(t *testing.T) {
 	pool := newMockPool(t, &mockWalletServer{})
-	result := callTool(t, handleTransferTRX(pool), map[string]any{
+	result := callTool(t, handleTransferTRX(pool, nil), map[string]any{
 		"from":   "invalid",
 		"to":     "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"amount": "100",
@@ -25,7 +26,7 @@ func TestTransferTRX_InvalidFromAddress(t *testing.T) {
 
 func TestTransferTRX_InvalidToAddress(t *testing.T) {
 	pool := newMockPool(t, &mockWalletServer{})
-	result := callTool(t, handleTransferTRX(pool), map[string]any{
+	result := callTool(t, handleTransferTRX(pool, nil), map[string]any{
 		"from":   "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":     "invalid",
 		"amount": "100",
@@ -35,7 +36,7 @@ func TestTransferTRX_InvalidToAddress(t *testing.T) {
 
 func TestTransferTRX_InvalidAmount(t *testing.T) {
 	pool := newMockPool(t, &mockWalletServer{})
-	result := callTool(t, handleTransferTRX(pool), map[string]any{
+	result := callTool(t, handleTransferTRX(pool, nil), map[string]any{
 		"from":   "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":     "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"amount": "abc",
@@ -45,7 +46,7 @@ func TestTransferTRX_InvalidAmount(t *testing.T) {
 
 func TestTransferTRX_ZeroAmount(t *testing.T) {
 	pool := newMockPool(t, &mockWalletServer{})
-	result := callTool(t, handleTransferTRX(pool), map[string]any{
+	result := callTool(t, handleTransferTRX(pool, nil), map[string]any{
 		"from":   "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":     "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"amount": "0",
@@ -65,7 +66,7 @@ func TestTransferTRX_Success(t *testing.T) {
 		},
 	}
 	pool := newMockPool(t, mock)
-	result := callTool(t, handleTransferTRX(pool), map[string]any{
+	result := callTool(t, handleTransferTRX(pool, nil), map[string]any{
 		"from":   "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":     "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
 		"amount": "100.5",
@@ -92,7 +93,7 @@ func TestTransferTRX_WithMemo(t *testing.T) {
 		},
 	}
 	pool := newMockPool(t, mock)
-	result := callTool(t, handleTransferTRX(pool), map[string]any{
+	result := callTool(t, handleTransferTRX(pool, nil), map[string]any{
 		"from":   "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":     "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
 		"amount": "1",
@@ -124,7 +125,7 @@ func TestTransferTRX_WithPermissionID(t *testing.T) {
 		},
 	}
 	pool := newMockPool(t, mock)
-	result := callTool(t, handleTransferTRX(pool), map[string]any{
+	result := callTool(t, handleTransferTRX(pool, nil), map[string]any{
 		"from":          "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":            "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
 		"amount":        "1",
@@ -144,7 +145,7 @@ func TestTransferTRX_WithPermissionID(t *testing.T) {
 
 func TestTransferTRC20_InvalidAddress(t *testing.T) {
 	pool := newMockPool(t, &mockWalletServer{})
-	result := callTool(t, handleTransferTRC20(pool, nil), map[string]any{
+	result := callTool(t, handleTransferTRC20(pool, nil, nil), map[string]any{
 		"from":             "invalid",
 		"to":               "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
@@ -155,7 +156,7 @@ func TestTransferTRC20_InvalidAddress(t *testing.T) {
 
 func TestTransferTRC20_InvalidContractAddress(t *testing.T) {
 	pool := newMockPool(t, &mockWalletServer{})
-	result := callTool(t, handleTransferTRC20(pool, nil), map[string]any{
+	result := callTool(t, handleTransferTRC20(pool, nil, nil), map[string]any{
 		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":               "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"contract_address": "invalid",
@@ -166,7 +167,7 @@ func TestTransferTRC20_InvalidContractAddress(t *testing.T) {
 
 func TestTransferTRC20_InvalidToAddress(t *testing.T) {
 	pool := newMockPool(t, &mockWalletServer{})
-	result := callTool(t, handleTransferTRC20(pool, nil), map[string]any{
+	result := callTool(t, handleTransferTRC20(pool, nil, nil), map[string]any{
 		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":               "bad",
 		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
@@ -186,7 +187,7 @@ func TestTransferTRC20_InvalidFeeLimit(t *testing.T) {
 		},
 	}
 	pool := newMockPool(t, mock)
-	result := callTool(t, handleTransferTRC20(pool, nil), map[string]any{
+	result := callTool(t, handleTransferTRC20(pool, nil, nil), map[string]any{
 		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":               "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
 		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
@@ -217,7 +218,7 @@ func TestTransferTRC20_Success(t *testing.T) {
 		},
 	}
 	pool := newMockPool(t, mock)
-	result := callTool(t, handleTransferTRC20(pool, nil), map[string]any{
+	result := callTool(t, handleTransferTRC20(pool, nil, nil), map[string]any{
 		"from":             "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF",
 		"to":               "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
 		"contract_address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
@@ -228,4 +229,53 @@ func TestTransferTRC20_Success(t *testing.T) {
 	data := parseJSONResult(t, result)
 	assert.Equal(t, "TriggerSmartContract", data["type"])
 	assert.NotEmpty(t, data["transaction_hex"], "transaction_hex should not be empty")
+}
+
+// --- resolveFromAddress tests ---
+
+func TestResolveFromAddress_NilWM_ValidAddress(t *testing.T) {
+	addr, err := resolveFromAddress(nil, "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF")
+	require.NoError(t, err)
+	assert.Equal(t, "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF", addr)
+}
+
+func TestResolveFromAddress_NilWM_InvalidAddress(t *testing.T) {
+	_, err := resolveFromAddress(nil, "not-an-address")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid from address")
+	assert.NotContains(t, err.Error(), "list_wallets", "should not mention list_wallets when no wallet manager")
+}
+
+func TestResolveFromAddress_WithWM_WalletName(t *testing.T) {
+	wm, err := wallet.NewManager(t.TempDir(), "test-pass")
+	require.NoError(t, err)
+	t.Cleanup(func() { wm.Close() })
+
+	addr, createErr := wm.CreateWallet("my-wallet")
+	require.NoError(t, createErr)
+
+	resolved, err := resolveFromAddress(wm, "my-wallet")
+	require.NoError(t, err)
+	assert.Equal(t, addr, resolved, "should resolve wallet name to address")
+}
+
+func TestResolveFromAddress_WithWM_RawAddress(t *testing.T) {
+	wm, err := wallet.NewManager(t.TempDir(), "test-pass")
+	require.NoError(t, err)
+	t.Cleanup(func() { wm.Close() })
+
+	// Pass a valid address directly — should work even without matching wallet
+	addr, err := resolveFromAddress(wm, "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF")
+	require.NoError(t, err)
+	assert.Equal(t, "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF", addr)
+}
+
+func TestResolveFromAddress_WithWM_UnknownName(t *testing.T) {
+	wm, err := wallet.NewManager(t.TempDir(), "test-pass")
+	require.NoError(t, err)
+	t.Cleanup(func() { wm.Close() })
+
+	_, err = resolveFromAddress(wm, "unknown-wallet")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list_wallets", "should hint to use list_wallets")
 }

--- a/internal/wallet/manager.go
+++ b/internal/wallet/manager.go
@@ -82,7 +82,7 @@ func (m *Manager) ListWallets() ([]WalletInfo, error) {
 // GetSigner returns a Signer for the named wallet or address.
 // The wallet is unlocked with the manager's passphrase.
 func (m *Manager) GetSigner(nameOrAddress string) (signer.Signer, error) {
-	addr, err := m.resolveAddress(nameOrAddress)
+	addr, err := m.ResolveAddress(nameOrAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -115,9 +115,9 @@ func (m *Manager) Close() {
 	m.store.CloseAll()
 }
 
-// resolveAddress converts a wallet name to its address, or returns the
+// ResolveAddress converts a wallet name to its address, or returns the
 // input if it's already a base58 address (starts with T).
-func (m *Manager) resolveAddress(nameOrAddress string) (string, error) {
+func (m *Manager) ResolveAddress(nameOrAddress string) (string, error) {
 	// Try as wallet name first
 	addr, err := m.store.AddressFromAccountName(nameOrAddress)
 	if err == nil {


### PR DESCRIPTION
## Summary

- **Elicitation confirmation** before broadcasting transactions when no policy engine is active — the MCP server pauses and shows the user a confirmation dialog with decoded transaction details (type, from, to, amount)
- **Wallet name resolution** in `transfer_trx` and `transfer_trc20` tools — agents can now pass a wallet name in the `from` field instead of requiring raw base58 addresses
- **TRC20 human-readable amounts** in the confirmation dialog — resolves token decimals and symbol from the network

### How elicitation works

When `sign_and_broadcast` or `sign_and_confirm` is called without a policy engine, the server sends an elicitation request to the MCP client showing the decoded transaction details. The user clicks **Accept** to proceed or **Decline** to cancel.

- Policy-protected wallets skip elicitation (policy engine is the safety net)
- Headless clients (no elicitation support) proceed silently — same behavior as before
- No new config flags — client capability is the toggle

### Wallet name resolution

`transfer_trx` and `transfer_trc20` now accept wallet names in `from`:
```
transfer_trx(from: "savings", to: "TKSXDA8...", amount: "100")
```
Falls back to address validation if no wallet manager or name not found. Clear error message with hint to use `list_wallets`.

### Files changed

- `internal/server/server.go` — `WithElicitation()`, moved transfer registration after wallet manager init
- `internal/tools/sign.go` — `requestBroadcastConfirmation` helper, wired into both sign handlers
- `internal/tools/sign_test.go` — 13 new tests: mock sessions, full-flow accept/decline/not-supported/policy-skips
- `internal/tools/transfer.go` — `resolveFromAddress` helper, wallet name resolution
- `internal/tools/token.go` — wallet manager param for TRC20 transfer handler
- `internal/tools/transfer_test.go` — updated for new signatures
- `internal/wallet/manager.go` — exported `ResolveAddress`

Closes #73

## Test plan

- [x] `go test -race ./...` — all 16 packages pass
- [x] `golangci-lint run` — 0 issues
- [x] 4-agent code review (pr-review-toolkit, CodeRabbit, Codex MCP, Security Auditor)
- [ ] Manual: elicitation dialog shows for TRX transfer (no policy)
- [ ] Manual: user Accept → broadcasts successfully
- [ ] Manual: user Decline → cancelled, no broadcast
- [ ] Manual: with policy active → no dialog, broadcasts directly
- [ ] Manual: headless client → no dialog, broadcasts normally
- [ ] Manual: `transfer_trx(from: "wallet-name")` resolves correctly
- [ ] Manual: TRC20 confirmation shows human-readable amount + symbol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive confirmation prompts before signing/broadcasting transactions, including token symbol and human-readable amount display.
  * Transfers accept wallet names as the sender ("from") in addition to raw addresses; sender resolution is attempted when a wallet is available.

* **Bug Fixes**
  * Cancelled confirmations now return a clear cancelled status and reason instead of proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->