### PR TITLE
feat: add MCP prompt workflows for common TRON operations

### DIFF
--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -1,0 +1,169 @@
+package prompts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// RegisterPrompts registers pre-built conversation starters for common workflows.
+func RegisterPrompts(s *server.MCPServer) {
+	s.AddPrompt(mcp.NewPrompt("account-overview",
+		mcp.WithPromptDescription("Get a complete overview of a TRON account: balance, resources, permissions, and delegations"),
+		mcp.WithArgument("address",
+			mcp.ArgumentDescription("TRON account address (base58, starts with T)"),
+			mcp.RequiredArgument(),
+		),
+	), handleAccountOverview)
+
+	s.AddPrompt(mcp.NewPrompt("transfer-checklist",
+		mcp.WithPromptDescription("Pre-flight checks before sending TRX or TRC20 tokens: balance, resources, address validation"),
+		mcp.WithArgument("from",
+			mcp.ArgumentDescription("Sender address or wallet name"),
+			mcp.RequiredArgument(),
+		),
+		mcp.WithArgument("to",
+			mcp.ArgumentDescription("Recipient address (base58, starts with T)"),
+			mcp.RequiredArgument(),
+		),
+		mcp.WithArgument("amount",
+			mcp.ArgumentDescription("Amount to send (e.g., '100.5')"),
+			mcp.RequiredArgument(),
+		),
+		mcp.WithArgument("token",
+			mcp.ArgumentDescription("Token to send: 'TRX' (default) or TRC20 contract address"),
+		),
+	), handleTransferChecklist)
+
+	s.AddPrompt(mcp.NewPrompt("transaction-explain",
+		mcp.WithPromptDescription("Look up a transaction and explain what it did in plain language"),
+		mcp.WithArgument("txid",
+			mcp.ArgumentDescription("Transaction ID (64-character hex hash)"),
+			mcp.RequiredArgument(),
+		),
+	), handleTransactionExplain)
+
+	s.AddPrompt(mcp.NewPrompt("staking-status",
+		mcp.WithPromptDescription("Show the complete staking position: frozen TRX, delegations, votes, and pending unfreezes"),
+		mcp.WithArgument("address",
+			mcp.ArgumentDescription("TRON account address (base58, starts with T)"),
+			mcp.RequiredArgument(),
+		),
+	), handleStakingStatus)
+}
+
+func handleAccountOverview(_ context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	address := req.Params.Arguments["address"]
+	if address == "" {
+		return nil, fmt.Errorf("address is required")
+	}
+
+	return &mcp.GetPromptResult{
+		Description: "Complete TRON account overview",
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: fmt.Sprintf(
+						"Give me a complete overview of the TRON account %s. "+
+							"Include: TRX balance, token balances, energy and bandwidth "+
+							"(used/available/limit), account permissions (owner, active, "+
+							"any multi-sig setup), and delegated resources (incoming and outgoing).",
+						address,
+					),
+				},
+			},
+		},
+	}, nil
+}
+
+func handleTransferChecklist(_ context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	from := req.Params.Arguments["from"]
+	to := req.Params.Arguments["to"]
+	amount := req.Params.Arguments["amount"]
+	token := req.Params.Arguments["token"]
+
+	if from == "" || to == "" || amount == "" {
+		return nil, fmt.Errorf("from, to, and amount are required")
+	}
+	if token == "" {
+		token = "TRX"
+	}
+
+	return &mcp.GetPromptResult{
+		Description: "Pre-flight transfer checklist",
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: fmt.Sprintf(
+						"I want to transfer %s %s from %s to %s. "+
+							"Before building the transaction: validate both addresses, "+
+							"check the sender's balance is sufficient, estimate the energy "+
+							"and bandwidth cost, and verify the sender has enough resources "+
+							"to cover fees. Report any issues. Only build the transfer if "+
+							"everything checks out.",
+						amount, token, from, to,
+					),
+				},
+			},
+		},
+	}, nil
+}
+
+func handleTransactionExplain(_ context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	txid := req.Params.Arguments["txid"]
+	if txid == "" {
+		return nil, fmt.Errorf("txid is required")
+	}
+
+	return &mcp.GetPromptResult{
+		Description: "Transaction explanation",
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: fmt.Sprintf(
+						"Look up transaction %s and explain what it did. "+
+							"Include: the contract type, sender and recipient, amount "+
+							"transferred, success or failure status, and fee breakdown "+
+							"(energy used, bandwidth used, TRX burned). Explain in plain language.",
+						txid,
+					),
+				},
+			},
+		},
+	}, nil
+}
+
+func handleStakingStatus(_ context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	address := req.Params.Arguments["address"]
+	if address == "" {
+		return nil, fmt.Errorf("address is required")
+	}
+
+	return &mcp.GetPromptResult{
+		Description: "Staking position overview",
+		Messages: []mcp.PromptMessage{
+			{
+				Role: mcp.RoleUser,
+				Content: mcp.TextContent{
+					Type: "text",
+					Text: fmt.Sprintf(
+						"Show me the complete staking position for %s. "+
+							"Include: frozen/staked TRX balance, energy and bandwidth from "+
+							"staking, resources delegated to others, resources received from "+
+							"others, delegatable amounts remaining, any pending unfreezes, "+
+							"and current vote allocation if any.",
+						address,
+					),
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -1,0 +1,151 @@
+package prompts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterPrompts(t *testing.T) {
+	s := server.NewMCPServer("test", "1.0", server.WithPromptCapabilities(false))
+	RegisterPrompts(s)
+	// Should not panic — prompts registered successfully
+}
+
+func newPromptReq(args map[string]string) mcp.GetPromptRequest {
+	return mcp.GetPromptRequest{
+		Params: struct {
+			Name      string            `json:"name"`
+			Arguments map[string]string `json:"arguments,omitempty"`
+		}{
+			Arguments: args,
+		},
+	}
+}
+
+func TestAccountOverview(t *testing.T) {
+	req := newPromptReq(map[string]string{"address": "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF"})
+	result, err := handleAccountOverview(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, mcp.RoleUser, result.Messages[0].Role)
+
+	text := result.Messages[0].Content.(mcp.TextContent).Text
+	assert.Contains(t, text, "TKSXDA8HfE9E1y39RczVQ1ZascUEtaSToF")
+	assert.Contains(t, text, "balance")
+	assert.Contains(t, text, "energy")
+	assert.Contains(t, text, "permissions")
+	assert.Contains(t, text, "delegated")
+}
+
+func TestAccountOverview_MissingAddress(t *testing.T) {
+	req := newPromptReq(map[string]string{})
+	_, err := handleAccountOverview(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "address is required")
+}
+
+func TestTransferChecklist(t *testing.T) {
+	req := newPromptReq(map[string]string{
+		"from":   "TAddr1",
+		"to":     "TAddr2",
+		"amount": "100",
+	})
+	result, err := handleTransferChecklist(context.Background(), req)
+	require.NoError(t, err)
+
+	text := result.Messages[0].Content.(mcp.TextContent).Text
+	assert.Contains(t, text, "100 TRX")
+	assert.Contains(t, text, "TAddr1")
+	assert.Contains(t, text, "TAddr2")
+	assert.Contains(t, text, "validate")
+	assert.Contains(t, text, "balance")
+	assert.Contains(t, text, "energy")
+}
+
+func TestTransferChecklist_WithToken(t *testing.T) {
+	req := newPromptReq(map[string]string{
+		"from":   "TAddr1",
+		"to":     "TAddr2",
+		"amount": "50",
+		"token":  "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+	})
+	result, err := handleTransferChecklist(context.Background(), req)
+	require.NoError(t, err)
+
+	text := result.Messages[0].Content.(mcp.TextContent).Text
+	assert.Contains(t, text, "50 TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t")
+}
+
+func TestTransferChecklist_DefaultToken(t *testing.T) {
+	req := newPromptReq(map[string]string{
+		"from":   "TAddr1",
+		"to":     "TAddr2",
+		"amount": "10",
+	})
+	result, err := handleTransferChecklist(context.Background(), req)
+	require.NoError(t, err)
+
+	text := result.Messages[0].Content.(mcp.TextContent).Text
+	assert.Contains(t, text, "10 TRX")
+}
+
+func TestTransferChecklist_MissingArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]string
+	}{
+		{"missing from", map[string]string{"to": "T", "amount": "1"}},
+		{"missing to", map[string]string{"from": "T", "amount": "1"}},
+		{"missing amount", map[string]string{"from": "T", "to": "T"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := handleTransferChecklist(context.Background(), newPromptReq(tt.args))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestTransactionExplain(t *testing.T) {
+	txid := "abc123def456"
+	req := newPromptReq(map[string]string{"txid": txid})
+	result, err := handleTransactionExplain(context.Background(), req)
+	require.NoError(t, err)
+
+	text := result.Messages[0].Content.(mcp.TextContent).Text
+	assert.Contains(t, text, txid)
+	assert.Contains(t, text, "contract type")
+	assert.Contains(t, text, "fee breakdown")
+}
+
+func TestTransactionExplain_MissingTxid(t *testing.T) {
+	req := newPromptReq(map[string]string{})
+	_, err := handleTransactionExplain(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "txid is required")
+}
+
+func TestStakingStatus(t *testing.T) {
+	req := newPromptReq(map[string]string{"address": "TStaker123"})
+	result, err := handleStakingStatus(context.Background(), req)
+	require.NoError(t, err)
+
+	text := result.Messages[0].Content.(mcp.TextContent).Text
+	assert.Contains(t, text, "TStaker123")
+	assert.Contains(t, text, "staking")
+	assert.Contains(t, text, "delegat")
+	assert.Contains(t, text, "unfreeze")
+	assert.Contains(t, text, "vote")
+}
+
+func TestStakingStatus_MissingAddress(t *testing.T) {
+	req := newPromptReq(map[string]string{})
+	_, err := handleStakingStatus(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "address is required")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fbsobreira/gotron-mcp/internal/nodepool"
 	"github.com/fbsobreira/gotron-mcp/internal/policy"
 	"github.com/fbsobreira/gotron-mcp/internal/price"
+	"github.com/fbsobreira/gotron-mcp/internal/prompts"
 	"github.com/fbsobreira/gotron-mcp/internal/resources"
 	"github.com/fbsobreira/gotron-mcp/internal/tools"
 	"github.com/fbsobreira/gotron-mcp/internal/trongrid"
@@ -31,6 +32,7 @@ func New(cfg *config.Config, pool *nodepool.Pool) (*server.MCPServer, *wallet.Ma
 		version.Version,
 		server.WithToolCapabilities(false),
 		server.WithResourceCapabilities(false, false),
+		server.WithPromptCapabilities(false),
 		server.WithElicitation(),
 		server.WithInstructions(`GoTRON MCP server for TRON blockchain interaction.
 
@@ -66,6 +68,9 @@ Knowledge base resources available at gotron://knowledge/ for TRON concepts and 
 
 	// Knowledge base resources
 	resources.RegisterResources(s)
+
+	// Prompt workflows
+	prompts.RegisterPrompts(s)
 
 	// Always register read-only tools
 	tools.RegisterAccountTools(s, pool)


### PR DESCRIPTION
## Summary

Adds 4 MCP prompt workflows — pre-built conversation starters that guide agents through multi-tool workflows:

- **account-overview** — Complete account analysis: balance, resources, permissions, delegations
- **transfer-checklist** — Pre-flight checks before sending TRX/TRC20: validate addresses, check balance, estimate fees
- **transaction-explain** — Look up a transaction and explain what it did in plain language
- **staking-status** — Full staking position: frozen TRX, delegations, votes, pending unfreezes

### How it works

Each prompt returns a user-role message that naturally triggers the agent to call the right tools. No tool calls inside handlers — the agent figures out the chain from a clear request.

Prompts appear in Claude Desktop, MCP Inspector, and any MCP-compatible client.

### Files

- `internal/prompts/prompts.go` — 4 prompts with argument validation
- `internal/prompts/prompts_test.go` — 12 tests
- `internal/server/server.go` — `WithPromptCapabilities` + `RegisterPrompts`

Closes #78

## Test plan

- [x] `go test -race ./...` — all 17 packages pass
- [x] `golangci-lint run` — 0 issues
- [ ] Manual: prompts visible in MCP Inspector (`make inspector`)
- [ ] Manual: account-overview with real address returns full analysis
- [ ] Manual: transfer-checklist catches insufficient balance
- [ ] Manual: transaction-explain decodes a real transaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new AI-powered prompts: account overview, transfer checklist, transaction explanation, and staking status. Each prompt accepts relevant parameters to provide dynamic, context-specific guidance for blockchain interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->